### PR TITLE
New: Variable Definition Information of Config Files

### DIFF
--- a/designs/2019-variable-definition-information-of-config-files/README.md
+++ b/designs/2019-variable-definition-information-of-config-files/README.md
@@ -1,5 +1,5 @@
 - Start Date: 2019-03-04
-- RFC PR: (leave this empty, to be filled in later)
+- RFC PR: https://github.com/eslint/rfcs/pull/17
 - Authors: Toru Nagashima ([@mysticatea])
 
 # Variable Definition Information of Config Files

--- a/designs/2019-variable-definition-information-of-config-files/README.md
+++ b/designs/2019-variable-definition-information-of-config-files/README.md
@@ -1,0 +1,86 @@
+- Start Date: 2019-03-04
+- RFC PR: (leave this empty, to be filled in later)
+- Authors: Toru Nagashima ([@mysticatea])
+
+# Variable Definition Information of Config Files
+
+## Summary
+
+This proposal adds variable definition information of config files to `Variable` objects.
+
+## Motivation
+
+To make rules being able to report matters about variable definitions related to config files.
+
+Especially, this proposal minds [no-redeclare] rule to report redeclaration by a mix of regular variable declarations, `/*globals*/` comments, and config files. ([eslint/eslint#11370])
+
+## Detailed Design
+
+Currently, `Variable` objects have the following properties to express `/*globals*/` definitions.
+
+- `variable.eslintExplicitGlobal` (`boolean`) ... `true` if this variable was defined by `/*globals*/` comment.
+- `variable.eslintExplicitGlobalComment` (`Comment` object) ... The `/*globals*/` comment that defines this variable. If two or more comments defined this variable, it adopts the last one.
+- `variable.writeable` (`boolean`) ... `true` if the final setting is `"writable"`.
+
+This proposal adds the following properties.
+
+- `variable.eslintExplicitGlobalComments` (an array of `Comment` objects) ... All `/*globals*/` comments that define this variable.
+- `variable.eslintImplicitGlobalSetting` (`"readonly"` | `"writable"` | `null`) ... The setting in config files. This is `null` if config files didn't define it.
+
+Both `variable.eslintExplicitGlobalComments` and `variable.eslintImplicitGlobalSetting` are instantiated even if regular variable declarations (E.g. `let foo` syntax) exist. Therefore, [no-redeclare] rule can verify redeclaration by a mix of regular variable declarations, `/*globals*/` comments, and config files.
+
+This will be implemented into [`addDeclaredGlobals(globalScope, configGlobals, commentDirectives)`][lib/linter.js#L73-L131] function.
+
+<table><td>
+<a id="question1">❓</a> <b>Open Question</b>:<br>
+(<a href="question1a">link</a>) Should we handle de-declaration such as <code>/*globals foo:off*/</code>? Because variable objects don't exist for de-declared variables, rules cannot know de-declared variables under this proposal.
+</td></table>
+
+## Documentation
+
+All of the existing `variable.eslintExplicitGlobal`, `variable.eslintExplicitGlobalComment`, and `variable.writeable` are undocumented. So new properties also can be undocumented.
+
+<table><td>
+<a id="question2">❓</a> <b>Open Question</b>:<br>
+(<a href="question2a">link</a>) Should we document those properties as public API officially?
+</td></table>
+
+If we decided to make those properties public, it will be in [context.getScope()
+](https://eslint.org/docs/developer-guide/working-with-rules#contextgetscope) section so plugins can use those properties.
+
+## Drawbacks
+
+Rules get accessible to `globals` setting values. It might restrict us to change the system which declares global variables.
+
+## Backwards Compatibility Analysis
+
+This proposal doesn't change the existing things.
+
+If a plugin rule used `variable.eslintExplicitGlobalComments` property or `variable.eslintImplicitGlobalSetting` property for some reason, the rule will be broken. But it's a pretty little possibility.
+
+## Alternatives
+
+- Adding `context.getImplicitGlobalSettings()` method to `RuleContext` object to retrieve normalized `globals` setting. In this case, rules can know settings in config files even if `/*globals foo:off*/` comment existed. On the other hand, rules have to search and parse `/*globals*/` comments manually although ESLint core has handled those once.
+
+## Open Questions
+
+- (<a href="#question1" id="question1a">link</a>) Should we handle de-declaration such as `/*globals foo:off*/`? Because variable objects don't exist for de-declared variables, rules cannot know de-declared variables under this proposal.<br>
+  [@mysticatea]'s preference is no. The [no-redeclare] rule will ignore such a removed declaration because it's a corner case and ECMAScript doesn't have the analogy of that. Probably [eslint-plugin-eslint-comments] plugin can report such a de-declaration.
+
+- (<a href="#question2" id="question2a">link</a>) Should we document those properties as public API officially although all of the existing `variable.eslintExplicitGlobal`, `variable.eslintExplicitGlobalComment`, and `variable.writeable` are undocumented?<br>
+  [@mysticatea]'s preference is yes.
+
+## Frequently Asked Questions
+
+Nothing in particular yet.
+
+## Related Discussions
+
+- [eslint/eslint#11370]
+
+
+[@mysticatea]: https://github.com/mysticatea
+[eslint/eslint#11370]: https://github.com/eslint/eslint/issues/11370
+[lib/linter.js#L73-L131]: https://github.com/eslint/eslint/blob/b00a5e9d8dc6c5f77eb0e4e0c58dfaf12a771d7b/lib/linter.js#L73-L131
+[no-redeclare]: https://eslint.org/docs/rules/no-redeclare
+[eslint-plugin-eslint-comments]: https://github.com/mysticatea/eslint-plugin-eslint-comments

--- a/designs/2019-variable-definition-information-of-config-files/README.md
+++ b/designs/2019-variable-definition-information-of-config-files/README.md
@@ -27,26 +27,24 @@ This proposal adds the following properties.
 - `variable.eslintExplicitGlobalComments` (an array of `Comment` objects) ... All `/*globals*/` comments that define this variable.
 - `variable.eslintImplicitGlobalSetting` (`"readonly"` | `"writable"` | `null`) ... The setting in config files. This is `null` if config files didn't define it.
 
+And this proposal removes existing `variable.eslintExplicitGlobalComment` property in favor of new `variable.eslintExplicitGlobalComments` property.
+
 Both `variable.eslintExplicitGlobalComments` and `variable.eslintImplicitGlobalSetting` are instantiated even if regular variable declarations (E.g. `let foo` syntax) exist. Therefore, [no-redeclare] rule can verify redeclaration by a mix of regular variable declarations, `/*globals*/` comments, and config files.
 
 This will be implemented into [`addDeclaredGlobals(globalScope, configGlobals, commentDirectives)`][lib/linter.js#L73-L131] function.
 
-<table><td>
-<a id="question1">❓</a> <b>Open Question</b>:<br>
-(<a href="question1a">link</a>) Should we handle de-declaration such as <code>/*globals foo:off*/</code>? Because variable objects don't exist for de-declared variables, rules cannot know de-declared variables under this proposal.
-</td></table>
-
 ## Documentation
 
-All of the existing `variable.eslintExplicitGlobal`, `variable.eslintExplicitGlobalComment`, and `variable.writeable` are undocumented. So new properties also can be undocumented.
+This proposal is related to making rules. So [Working with Rules](https://eslint.org/docs/developer-guide/working-with-rules) page should describe those properties, including undocumented existing properties.
 
-<table><td>
-<a id="question2">❓</a> <b>Open Question</b>:<br>
-(<a href="question2a">link</a>) Should we document those properties as public API officially?
-</td></table>
+- `variable.writeable`
+- `variable.eslintExplicitGlobal`
+- `variable.eslintExplicitGlobalComments`
+- `variable.eslintImplicitGlobalSetting`
 
-If we decided to make those properties public, it will be in [context.getScope()
-](https://eslint.org/docs/developer-guide/working-with-rules#contextgetscope) section so plugins can use those properties.
+And, we should make an item in the migration guide. One undocumented property is removed.
+
+- `variable.eslintExplicitGlobalComment`
 
 ## Drawbacks
 
@@ -54,25 +52,13 @@ Rules get accessible to `globals` setting values. It might restrict us to change
 
 ## Backwards Compatibility Analysis
 
-This proposal doesn't change the existing things.
+If a plugin rule used `variable.eslintExplicitGlobalComment` property, because this proposal removes it, the rule will be broken. But that property was undocumented and [GitHub search](https://github.com/search?p=1&q=eslintExplicitGlobalComment+language%3Ajavascript&type=Code) shows only copies of `no-unused-vars` rule or ESLint core, so this removal is no danger. (One point, `eslint-plugin-closure` package has [the type definition of escope](https://github.com/google/eslint-closure/blob/bf5c0d4d2a67ea3e8394c228717ae23d1a1ae4ba/packages/eslint-plugin-closure/lib/externs/escope.js#L163). That will need to be tweaked regardless of the removal.)
 
 If a plugin rule used `variable.eslintExplicitGlobalComments` property or `variable.eslintImplicitGlobalSetting` property for some reason, the rule will be broken. But it's a pretty little possibility.
 
 ## Alternatives
 
 - Adding `context.getImplicitGlobalSettings()` method to `RuleContext` object to retrieve normalized `globals` setting. In this case, rules can know settings in config files even if `/*globals foo:off*/` comment existed. On the other hand, rules have to search and parse `/*globals*/` comments manually although ESLint core has handled those once.
-
-## Open Questions
-
-- (<a href="#question1" id="question1a">link</a>) Should we handle de-declaration such as `/*globals foo:off*/`? Because variable objects don't exist for de-declared variables, rules cannot know de-declared variables under this proposal.<br>
-  [@mysticatea]'s preference is no. The [no-redeclare] rule will ignore such a removed declaration because it's a corner case and ECMAScript doesn't have the analogy of that. Probably [eslint-plugin-eslint-comments] plugin can report such a de-declaration.
-
-- (<a href="#question2" id="question2a">link</a>) Should we document those properties as public API officially although all of the existing `variable.eslintExplicitGlobal`, `variable.eslintExplicitGlobalComment`, and `variable.writeable` are undocumented?<br>
-  [@mysticatea]'s preference is yes.
-
-## Frequently Asked Questions
-
-Nothing in particular yet.
 
 ## Related Discussions
 


### PR DESCRIPTION
> Link to [Rendered RFC](https://github.com/eslint/rfcs/blob/2019-variable-definition-information-of-config-files/designs/2019-variable-definition-information-of-config-files/README.md)

## Summary

This proposal adds variable definition information of config files to `Variable` objects.

## Related Issues

- eslint/eslint#11370

