### PR TITLE
New: Config Tester

### DIFF
--- a/designs/2019-config-tester/README.md
+++ b/designs/2019-config-tester/README.md
@@ -37,14 +37,14 @@ const options = {
 }
 
 // Verify a shareable config (a path to the target file).
-tester.run("index.js", options)
-tester.run("es5.js", options)
-tester.run("es2015.js", options)
+tester.runOnConfigFile("index.js", options)
+tester.runOnConfigFile("es5.js", options)
+tester.runOnConfigFile("es2015.js", options)
 
 // Or verify plugin's preset configs (a config name in the plugin).
-tester.run("base", options)
-tester.run("recommended", options)
-tester.run("opinionated", options)
+tester.runOnPluginConfig("base", options)
+tester.runOnPluginConfig("recommended", options)
+tester.runOnPluginConfig("opinionated", options)
 ```
 
 ### § `ConfigTester(projectRoot)` constructor
@@ -67,7 +67,7 @@ The tester reads `` `${projectRoot}/package.json` `` to use in `run()` method.
 <b>🔗PoC</b>: <a href="https://github.com/eslint/eslint/blob/2fb21b5dd52c81fe3c93cce0eb5fda3bf7789da0/lib/config-tester/config-tester.js#L60-L66">lib/config-tester/config-tester.js#L60-L66</a>
 </td></tr></table>
 
-### § `tester.run(targetName, options)` method
+### § `tester.runOnConfigFile(filePath, options)` method / `tester.runOnPluginConfig(configName, options)` method
 
 Validates a config data.
 
@@ -75,7 +75,8 @@ Validates a config data.
 
 Name | Description
 :----|:-----------
-`targetName` | Required. If this package was a plugin, this is a config name of the plugin. Otherwise, this is a path to a file (relative from `projectRoot`).
+`filePath` | Required. This is a path to a file (relative from `projectRoot`).
+`configName` | Required. This is a config name of the plugin. If it cannot load the entry file (`main` field in `${projectRoot}/package.json` or `${projectRoot}/index.js`), it throws `MODULE_NOT_FOUND_ERROR`.
 `options.ignoreDeprecatedRules` | Default is `false`. If `true` then the tester ignores deprecated rules.
 `options.ignoreDisabledUnknownRules` | Default is `false`. If `true` then the tester ignores unknown rules if the rule was configured as `0` (`"off"`).
 `options.ignoreRulesMissingFromConfig` | Default is `false`. If `true` then the tester ignores missing rules. The missing rules mean the rules that ESLint or a plugin defined but not configured.

--- a/designs/2019-config-tester/README.md
+++ b/designs/2019-config-tester/README.md
@@ -33,7 +33,7 @@ const options = {
     ignoreDeprecatedRules: false,
     ignoreDisabledUnknownRules: false,
     ignoreMissingDependencies: false,
-    ignoreMissingRules: false,
+    ignoreRulesMissingFromConfig: false,
 }
 
 // Verify a shareable config (a path to the target file).
@@ -78,7 +78,7 @@ Name | Description
 `targetName` | Required. If this package was a plugin, this is a config name of the plugin. Otherwise, this is a path to a file (relative from `projectRoot`).
 `options.ignoreDeprecatedRules` | Default is `false`. If `true` then the tester ignores deprecated rules.
 `options.ignoreDisabledUnknownRules` | Default is `false`. If `true` then the tester ignores unknown rules if the rule was configured as `0` (`"off"`).
-`options.ignoreMissingRules` | Default is `false`. If `true` then the tester ignores missing rules. The missing rules mean the rules that ESLint or a plugin defined but not configured.
+`options.ignoreRulesMissingFromConfig` | Default is `false`. If `true` then the tester ignores missing rules. The missing rules mean the rules that ESLint or a plugin defined but not configured.
 `options.ignoreMissingDependencies` | Default is `false`. If `true` then the tester ignores wrong dependency definition (`dependencies`/`peerDependencies`).
 
 #### Behavior
@@ -108,7 +108,7 @@ Similarly to `RuleTester`, `ConfigTester` defines tests by `describe` and `it` g
     <b>🔗PoC</b>: <a href="https://github.com/eslint/eslint/blob/2fb21b5dd52c81fe3c93cce0eb5fda3bf7789da0/lib/config-tester/config-tester.js#L301-L338">lib/config-tester/config-tester.js#L301-L338</a>
     </td></tr></table>
 1. Check whether the config congiures all rules.
-    - If `ignoreMissingRules` option was `true`, the tester skips this step.
+    - If `ignoreRulesMissingFromConfig` option was `true`, the tester skips this step.
     - This step lets people know about new rules.
     <table><tr><td>
     <b>🔗PoC</b>: <a href="https://github.com/eslint/eslint/blob/2fb21b5dd52c81fe3c93cce0eb5fda3bf7789da0/lib/config-tester/config-tester.js#L340-L363">lib/config-tester/config-tester.js#L340-L363</a>

--- a/designs/2019-config-tester/README.md
+++ b/designs/2019-config-tester/README.md
@@ -1,0 +1,108 @@
+- Start Date: 2019-06-14
+- RFC PR: (leave this empty, to be filled in later)
+- Authors: Toru Nagashima &lt;https://github.com/mysticatea&gt;
+
+# Config Tester
+
+## Summary
+
+Providing `ConfigTester` API that tests shareable configs and plugin's preset configs.
+
+## Motivation
+
+Currently, we don't provide stuff to test shareable configs. This means the community doesn't have an easy way to check if their config is good or not.
+
+- Is the config structure valid?
+- Does every rule exist?
+- Does every rule have valid options?
+- Aren't there any deprecated rules?
+- Are there plugin settings of configured rules?
+- Will this config work after publish?
+    - Does `package.json` have parsers, plugins, and extended configs?
+
+## Detailed Design
+
+This RFC adds `ConfigTester` API to check configs.
+
+```js
+const { ConfigTester } = require("eslint")
+
+// Instantiate the tester.
+const tester = new ConfigTester({
+    projectRoot: process.cwd(),
+    ignoreMissingRules: false,
+    ignoreMissingDependencies: false
+})
+
+// Verify a shareable config.
+tester.run("eslint-config-xxxx", require("../lib/index.js"))
+
+// Or verify plugin's preset configs.
+tester.run("eslint-plugin-xxxx/recommended", require("../lib/configs/recommended.js"))
+tester.run("eslint-plugin-xxxx/opinionated", require("../lib/configs/opinionated.js"))
+```
+
+### § `ConfigTester(options)` constructor
+
+#### Parameters
+
+The constructor has an optional parameter.
+
+Name | Description
+:----|:-----------
+`options.projectRoot` | Default is `process.cwd()`. The path to the project root. The root should contain `package.json`.
+`options.ignoreMissingRules` | Default is `false`. If `true` then the tester ignores missing rules. The missing rules mean the rules that ESLint or a plugin defined but not configured.
+`options.ignoreMissingDependencies` | Default is `false`. If `true` then the tester ignores wrong dependency definition (`dependencies`/`peerDependencies`).
+
+### § `tester.run(displayName, config)` method
+
+Validates a config data.
+
+#### Parameters
+
+Name | Description
+:----|:-----------
+`displayName` | Required. The display name of this check.
+`config` | Required. The config object to check.
+
+#### Behavior
+
+Similarly to `RuleTester`, `ConfigTester` defines tests by `describe` and `it` global variables. Then it does:
+
+1. Validate the config object has the valid scheme ([validateConfigScheme(config, source)](https://github.com/eslint/eslint/blob/aef8ea1a44b9f13d468f48536c4c93f79f201d9b/lib/shared/config-validator.js#L282)).
+1. Parse the config to `ConfigArray` with [ConfigArrayFactory#create(config, options)](https://github.com/eslint/eslint/blob/aef8ea1a44b9f13d468f48536c4c93f79f201d9b/lib/cli-engine/config-array-factory.js#L360).
+    - `cwd` and `resolvePluginsRelativeTo` options of the factory are `options.projectRoot`.
+    - if the `name` field of `${options.projectRoot}/package.json` is an ESLint plugin name, it loads the `main` field's file then adds it to `additionalPluginPool`.
+1. Validate the content ([validateConfigArray(configArray)](https://github.com/eslint/eslint/blob/aef8ea1a44b9f13d468f48536c4c93f79f201d9b/lib/shared/config-validator.js#L322)).
+1. Report non-existence rules.
+    - Because `validateConfigArray(configArray)` ignores non-existence rules.
+    - Configured plugin's rules are in `configArray.pluginRules`.
+1. Report deprecated rules if it's `warn` or `error`.
+    - Check `meta.deprecated` in core rules and `configArray.pluginRules`.
+1. If `options.ignoreMissingRules` was not `true`, check whether the config contains the settings of all rules.
+1. If `options.ignoreMissingDependencies` was not `true`, check whether `${options.projectRoot}/package.json` contains the configured parser, plugins, and shareable configs.
+    - If `parser` or `extends` were a file path except `node_modules/**`, the file should be published; check `.npmignore` and `package.json`'s `lib` field.
+    - If `parser` or `extends` were a package or a file path to `node_modules/**`, the package should be in `dependencies` or `peerDependencies`.
+    - `plugins` should be in `peerDependencies` or `name`.
+
+## Documentation
+
+- [Node.js API](https://eslint.org/docs/developer-guide/nodejs-api) page should describe the new `ConfigTester` API.
+- [Creating a Shareable Config](https://eslint.org/docs/developer-guide/shareable-configs#creating-a-shareable-config) section should note the tester.
+- [Configs in Plugins](https://eslint.org/docs/developer-guide/working-with-plugins#configs-in-plugins) section should note the tester.
+
+## Drawbacks
+
+- If people can write the config with no mistakes, this tester may not be needed.
+
+## Backwards Compatibility Analysis
+
+- This is not a breaking change. It just adds a new API.
+
+## Alternatives
+
+- https://www.npmjs.com/package/eslint-find-rules - we can check missing rules and deprecated rules with this package.
+
+## Related Discussions
+
+- https://github.com/eslint/eslint/issues/10289

--- a/designs/2019-config-tester/README.md
+++ b/designs/2019-config-tester/README.md
@@ -1,5 +1,5 @@
 - Start Date: 2019-06-14
-- RFC PR: (leave this empty, to be filled in later)
+- RFC PR: https://github.com/eslint/rfcs/pull/27
 - Authors: Toru Nagashima &lt;https://github.com/mysticatea&gt;
 
 # Config Tester

--- a/designs/2019-config-tester/README.md
+++ b/designs/2019-config-tester/README.md
@@ -64,7 +64,7 @@ Name | Description
 The tester reads `` `${projectRoot}/package.json` `` to use in `run()` method.
 
 <table><tr><td>
-<b>⏩ PoC</b>: <a href="https://github.com/eslint/eslint/blob/2fb21b5dd52c81fe3c93cce0eb5fda3bf7789da0/lib/config-tester/config-tester.js#L60-L66">lib/config-tester/config-tester.js#L60-L66</a>
+<b>🔗PoC</b>: <a href="https://github.com/eslint/eslint/blob/2fb21b5dd52c81fe3c93cce0eb5fda3bf7789da0/lib/config-tester/config-tester.js#L60-L66">lib/config-tester/config-tester.js#L60-L66</a>
 </td></tr></table>
 
 ### § `tester.run(targetName, options)` method

--- a/designs/2019-config-tester/README.md
+++ b/designs/2019-config-tester/README.md
@@ -107,7 +107,7 @@ Similarly to `RuleTester`, `ConfigTester` defines tests by `describe` and `it` g
     <table><tr><td>
     <b>🔗PoC</b>: <a href="https://github.com/eslint/eslint/blob/2fb21b5dd52c81fe3c93cce0eb5fda3bf7789da0/lib/config-tester/config-tester.js#L301-L338">lib/config-tester/config-tester.js#L301-L338</a>
     </td></tr></table>
-1. Check whether the config congiures all rules.
+1. Check whether the config configures all rules.
     - If `ignoreRulesMissingFromConfig` option was `true`, the tester skips this step.
     - This step lets people know about new rules.
     <table><tr><td>


### PR DESCRIPTION
> - [Rendered RFC](https://github.com/eslint/rfcs/blob/2019-config-tester/designs/2019-config-tester/README.md)
> - PoC: `npm i eslint/eslint#config-tester`

## Summary

Providing `ConfigTester` API that tests shareable configs and plugin's preset configs.

## Related Issues

- https://github.com/eslint/eslint/issues/10289
