### PR TITLE
New: Pass cwd from cli engine

### DIFF
--- a/designs/2019-pass-cwd-from-cli-engine/README.md
+++ b/designs/2019-pass-cwd-from-cli-engine/README.md
@@ -24,19 +24,19 @@ It is expected that the rule has access to the `cwd` in the option of the CLI en
 
 ## Detailed Design
 ### Change in Linter
-Modify the `Linter` constructor to accept an object with a nullable string parameter `cwd`.
+Modify the `Linter` constructor to accept an object with a optional string parameter `cwd` with a default value.
 ```
 const linter = new Linter({
   cwd: '/path/to/cwd'
 });
 ```
 or `const linter = new Linter({})`.
+The default value will be `process.cwd()` if the `process` exists, or `undefined` if not.
+
 
 ### Change in Context
 This RFC adds `getCwd()` method to rule context.
 The `getCwd()` method returns the value of the `cwd` option that was given in `Linter` constructor.
-If the `cwd` is `undefined` in the `Linter` but the `process` exists, `getCwd()` will return `process.cwd()`.
-If both of the `cwd` and the `process` are undefined, `getCwd()` will return `undefined`.
 
 https://github.com/eslint/eslint/pull/12021
 

--- a/designs/2019-pass-cwd-from-cli-engine/README.md
+++ b/designs/2019-pass-cwd-from-cli-engine/README.md
@@ -1,0 +1,50 @@
+- Start Date: 2019-07-25
+- RFC PR: https://github.com/eslint/eslint/pull/12021
+- Authors: Eric Wang
+
+# Pass cwd from cli engine
+
+## Summary
+Make the CLIEngine `cwd` option available to rules to avoid the misalignment between it and process.cwd()
+
+see: https://github.com/eslint/eslint/issues/11218
+
+## Motivation
+To avoid the misalignment between it and process.cwd().
+
+Use case:
+Say, the project is supposed to be open in `web` folder.
+But as the project grows, prople tends to open some subfolder under the `web` to minimize sidebar.
+`eslint` plugin in VSCode will then run the `eslint` from the subfolder which cause the `process.cwd` not to return the expected value (e.g. the `web` folder)
+
+Expected:
+It is expected that the rule has access to the `cwd` in the option of the CLI engine.
+
+## Detailed Design
+It could be easier to look at the code directly, as it has 15 LOC
+https://github.com/eslint/eslint/pull/12021
+
+## Documentation
+I don't think it's a big change.
+Adding the `cwd` into the `context` Api should be enough.
+
+## Drawbacks
+Can't think of any.
+
+## Backwards Compatibility Analysis
+Those rules using `process.cwd` will have exact same behavior, so there is no compatibility issue.
+
+## Alternatives
+N/A
+
+## Open Questions
+N/A
+
+## Help Needed
+N/A
+
+## Frequently Asked Questions
+N/A
+
+## Related Discussions
+N/A

--- a/designs/2019-pass-cwd-from-cli-engine/README.md
+++ b/designs/2019-pass-cwd-from-cli-engine/README.md
@@ -11,6 +11,8 @@ see: https://github.com/eslint/eslint/issues/11218
 
 ## Motivation
 To avoid the misalignment between it and process.cwd().
+There is a situation where a rule need to get the relative path of the current file to the root folder of the project.
+But it's hard to guarantee that all developers will open the root folder in their IDE (VSCode with eslint plugin for example), especially when the project grows.
 
 Use case:
 Say, the project is supposed to be open in `web` folder.

--- a/designs/2019-pass-cwd-from-cli-engine/README.md
+++ b/designs/2019-pass-cwd-from-cli-engine/README.md
@@ -1,5 +1,5 @@
 - Start Date: 2019-07-25
-- RFC PR: https://github.com/eslint/eslint/pull/12021
+- RFC PR: https://github.com/eslint/rfcs/pull/35
 - Authors: Eric Wang
 
 # Pass cwd from cli engine
@@ -14,19 +14,23 @@ To avoid the misalignment between it and process.cwd().
 
 Use case:
 Say, the project is supposed to be open in `web` folder.
-But as the project grows, prople tends to open some subfolder under the `web` to minimize sidebar.
+But as the project grows, people tends to open some subfolder under the `web` to minimize sidebar.
 `eslint` plugin in VSCode will then run the `eslint` from the subfolder which cause the `process.cwd` not to return the expected value (e.g. the `web` folder)
 
 Expected:
 It is expected that the rule has access to the `cwd` in the option of the CLI engine.
 
 ## Detailed Design
-It could be easier to look at the code directly, as it has 15 LOC
+Refactor the `Linter` constructor to accept a nullable string parameter `cwd`.
+Refactor the `runRules` method in `linter.js` to accept the nullable string parameter `cwd`, and pass it to the shared context so the rule can access it via `context`.
+If the `cwd` is `undefined`, `process` exists, it will be `process.cwd()`.
+If both of the `cwd` and the `process` are undefined, it will be undefined.
+
 https://github.com/eslint/eslint/pull/12021
 
 ## Documentation
-I don't think it's a big change.
-Adding the `cwd` into the `context` Api should be enough.
+Adding the `cwd` into the `context` Api.
+Adding the `cwd` into the `Linter` constructor Api.
 
 ## Drawbacks
 Can't think of any.

--- a/designs/2019-pass-cwd-from-cli-engine/README.md
+++ b/designs/2019-pass-cwd-from-cli-engine/README.md
@@ -10,7 +10,7 @@ Make the CLIEngine `cwd` option available to rules to avoid the misalignment bet
 see: https://github.com/eslint/eslint/issues/11218
 
 ## Motivation
-To avoid the misalignment between it and process.cwd().
+To avoid the misalignment between it and `process.cwd()`.
 There is a situation where a rule need to get the relative path of the current file to the root folder of the project.
 But it's hard to guarantee that all developers will open the root folder in their IDE (VSCode with eslint plugin for example), especially when the project grows.
 
@@ -23,10 +23,20 @@ Expected:
 It is expected that the rule has access to the `cwd` in the option of the CLI engine.
 
 ## Detailed Design
-Refactor the `Linter` constructor to accept a nullable string parameter `cwd`.
-Refactor the `runRules` method in `linter.js` to accept the nullable string parameter `cwd`, and pass it to the shared context so the rule can access it via `context`.
-If the `cwd` is `undefined`, `process` exists, it will be `process.cwd()`.
-If both of the `cwd` and the `process` are undefined, it will be undefined.
+### Change in Linter
+Modify the `Linter` constructor to accept an object with a nullable string parameter `cwd`.
+```
+const linter = new Linter({
+  cwd: '/path/to/cwd'
+});
+```
+or `const linter = new Linter({})`.
+
+### Change in Context
+This RFC adds `getCwd()` method to rule context.
+The `getCwd()` method returns the value of the `cwd` option that was given in `Linter` constructor.
+If the `cwd` is `undefined` in the `Linter` but the `process` exists, `getCwd()` will return `process.cwd()`.
+If both of the `cwd` and the `process` are undefined, `getCwd()` will return `undefined`.
 
 https://github.com/eslint/eslint/pull/12021
 


### PR DESCRIPTION
## Summary

Make the CLIEngine `cwd` option available to rules to avoid the misalignment between it and process.cwd()

see: https://github.com/eslint/eslint/issues/11218

## Related Issues

https://github.com/eslint/eslint/issues/11218

