### PR TITLE
New: `ESLint` Class Replacing `CLIEngine`

### DIFF
--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -20,13 +20,13 @@ The name of new class, `ESLint`, is our primary API clearly.
 
 ## Detailed Design
 
-### Add new `ESLint` class
+### ■ Add new `ESLint` class
 
 This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine`, but the return value of some methods are different.
 
 So, for now, `ESLint` class will be a tiny wrapper of `CLIEngine` that modifies the type of the return values.
 
-#### The `executeOnFiles()` method
+#### § The `executeOnFiles()` method
 
 This method returns a `AsyncIterator<LintResult>` object iterates the lint result of each file in random order.
 
@@ -80,7 +80,7 @@ print(results)
 
 Once the `executeOnFiles()` method got this change, we can support "linting in parallel", streaming, and plugins/configs which are ES modules in the future.
 
-#### The `getFormatter()` method
+#### § The `getFormatter()` method
 
 This method returns a `Promise<Formatter>`. The `Formatter` type is a function `(results: AsyncIterator<LintResult>) => AsyncIterator<string>`. It receives lint results then outputs the formatted text.
 
@@ -136,7 +136,7 @@ for await (const textPiece of formatter(results)) {
 
 Once the `getFormatter()` method got this change, we can update the specification of custom formatters without breakage in the future to support streaming.
 
-#### The other methods
+#### § The other methods
 
 The following methods return `Promise` which gets fulfilled with each result.
 
@@ -157,7 +157,7 @@ The following methods are removed because those don't fit the current API.
 
 - `resolveFileGlobPatterns()` ... ESLint doesn't use this logic since `v6.0.0`, but it has stayed there for backward compatibility. Once [RFC 20](https://github.com/eslint/rfcs/tree/master/designs/2019-additional-lint-targets) is implemented, what ESLint iterates and what the glob of this method iterates will be different, then it will confuse users. This is good timing to remove the legacy.
 
-#### A new `filterErrorResults()` static method
+#### § A new `filterErrorResults()` static method
 
 Existing `getErrorResults()` method doesn't fit the new `executeOnFiles()` method because the result is an async iterator.
 
@@ -210,13 +210,13 @@ for await (const textPiece of formatter(results)) {
 
 </details>
 
-### Deprecate `CLIEngine` class
+### ■ Deprecate `CLIEngine` class
 
 This RFC soft-deprecates `CLIEngine` class.
 
 Because it's tough to maintain two versions (sync and async) of implementation. The two are almost copy-pasted stuff, but hard to share the code. Therefore, this RFC deprecates the sync version to improve our code with the way which needs asynchronous behavior in the future. For example, `CLIEngine` cannot support parallel linting, plugins/configs as ES modules, etc...
 
-### Out of scope
+### ■ Out of scope
 
 - Not change API for rules. This RFC doesn't change APIs that rule implementation uses. We may be able to support asynchronous stuff in rules in the future, but it's out of this RFC's scope.
 - Not change internal logics. This RFC just adds the public interface that is asynchronous. It would be a wrapper of `CLIEngine` for now.

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -168,7 +168,7 @@ Because this method updates the cache file, it will break of called multiple tim
 
 The iterator has optional [`return()` method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return). The `for-of`/`for-await-of` syntax calls the `return()` method automatically if the execution escaped from the loop by `braek`, `return`, or `throw`. In short, the `return()` method will be called when aborted.
 
-Therefore, ESLint aborts linting when the `return()` method is called. This will mean that the `return()` method terminates all workers once we implement parallel linting.
+ESLint aborts all linting when the `return()` method is called. This will eg. terminate all workers if parallel linting is implemented.
 
 ```js
 const { ESLint } = require("eslint")

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -15,50 +15,178 @@ This RFC adds a new class `ESLint` that has asynchronous API and deprecates `CLI
 
 Because the migration of public API needs long time, we should start to migrate our APIs earlier.
 
-And the name of `CLIEngine`, our primary API, causes confusion to the community. People try `Linter` class at first, then they notice it doesn't work as expected. We have a lot of issues that say "please use `CLIEngine` instead."
+And the name of `CLIEngine`, our primary API, causes confusion to the community. People try `Linter` class at first because the name sounds the main class of ESLint, then they notice it doesn't work as expected. We have a lot of issues that say "please use `CLIEngine` instead."
 The name of new class, `ESLint`, is our primary API clearly.
 
 ## Detailed Design
 
 ### Add new `ESLint` class
 
-This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine`, but the following methods return `Promise`.
+This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine`, but the return value of some methods are different.
 
-- `executeOnFiles()`
+So, for now, `ESLint` class will be a tiny wrapper of `CLIEngine` that modifies the type of the return values.
+
+#### The `executeOnFiles()` method
+
+This method returns a `AsyncIterator<LintResult>` object iterates the lint result of each file in random order.
+
+<details>
+<summary>A rough sketch of the `executeOnFiles()` method.</summary>
+
+```js
+class ESLint {
+  async *executeOnFiles(patterns) {
+    // Verify files and push the results.
+    for (const result of this.cliEngine.executeOnFiles(patterns).results) {
+      yield result
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Example: Show the results step by step.</summary>
+
+```js
+const { ESLint } = require("eslint")
+const eslint = new ESLint()
+
+for await (const result of eslint.executeOnFiles(patterns)) {
+  print(result)
+}
+```
+
+</details>
+
+<details>
+<summary>Example: Show the results in the stable order.</summary>
+
+```js
+const { ESLint } = require("eslint")
+const eslint = new ESLint()
+const results = []
+
+for await (const result of eslint.executeOnFiles(patterns)) {
+  results.push(result)
+}
+
+results.sort(byFilePath)
+print(results)
+```
+
+</details>
+
+Once the `executeOnFiles()` method got this change, we can support "linting in parallel", streaming, and plugins/configs which are ES modules in the future.
+
+#### The `getFormatter()` method
+
+This method returns a `Promise<Formatter>`. The `Formatter` type is a function `(results: AsyncIterator<LintResult>) => AsyncIterator<string>`. It receives lint results then outputs the formatted text.
+
+This means the `getFormatter()` method wraps the current formatter to align the interface.
+
+<details>
+<summary>A rough sketch of the `getFormatter()` method.</summary>
+
+```js
+class ESLint {
+  async getFormatter(name) {
+    const format = this.cliEngine.getFormatter(name)
+
+    // Return the wrapper.
+    return async function* formatter(resultIterator) {
+      // Collect the results.
+      const results = []
+      for await (const result of resultIterator) {
+        results.push(result)
+      }
+      results.sort(byFilePath)
+
+      // Make `rulesMeta`.
+      const rules = this.cliEngine.getRules()
+      const rulesMeta = getRulesMeta(rules)
+
+      // Format the results with the formatter of the current spec.
+      yield format(results, { rulesMeta })
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Example: Use the formatter.</summary>
+
+```js
+const { ESLint } = require("eslint")
+const eslint = new ESLint()
+const formatter = eslint.getFormatter("stylish")
+
+// Verify files
+const results = eslint.executeOnFiles(patterns)
+// Format and write the results
+for await (const textPiece of formatter(results)) {
+    process.stdout.write(textPiece)
+}
+```
+
+</details>
+
+Once the `getFormatter()` method got this change, we can update the specification of custom formatters without breakage in the future to support streaming.
+
+#### The other methods
+
+The following methods return `Promise` which gets fulfilled with each result.
+
 - `executeOnText()`
 - `getConfigForFile()`
 - `isPathIgnored()`
 - `outputFixes()`
 
-And the following method returns a `Promise<(results: LintReport, metadata: any) => stream.Readable>`.
-
-- `getFormatter()`
-
-<details>
-
-```js
-    getFormatter(name) {
-        const formatter = cliEngine.getFormatter(name)
-        return Promise.resolve((...args) => {
-            const text = formatter(...args)
-            const s = new stream.PassThrough()
-            process.nextTick(() => {
-                s.write(text)
-                s.end()
-            })
-            return s
-        })
-    }
-```
-
-</details>
+Once the former three methods got this change, we can support plugins/configs that are ES modules without breakage in the future. And once the `outputFixes()` method got this change, we can write many files more efficiently in the future.
 
 The following methods are as-is because those don't touch both file system and module system.
 
 - `addPlugin()`
-- `getErrorResults()`
 - `getRules()`
-- `resolveFileGlobPatterns()`
+- `getErrorResults()`
+
+The following methods are removed because those don't fit the current API.
+
+- `resolveFileGlobPatterns()` ... ESLint doesn't use this logic since `v6.0.0`, but it has stayed there for backward compatibility. Once [RFC 20](https://github.com/eslint/rfcs/tree/master/designs/2019-additional-lint-targets) is implemented, what ESLint iterates and what the glob of this method iterates will be different, then it will confuse users. This is good timing to remove the legacy.
+
+#### A new `filterErrorResults()` static method
+
+Existing `getErrorResults()` method doesn't fit the new `executeOnFiles()` method because the result is an async iterator.
+
+The new `filterErrorResults()` method receives an `AsyncIterator<LintResult>` object and returns an `AsyncIterator<LintResult>` object. It extracts only the lint messages which are `severity === 2`, abandons the other messages.
+
+<details>
+<summary>A rough sketch of the `filterErrorResults()` static method.</summary>
+
+```js
+class ESLint {
+  static async *filterErrorResults(results) {
+    for await (const result of results) {
+      const messages = result.messages.filter(m => m.severity === 2)
+
+      if (messages.length === result.messages.length) {
+        yield result
+      }
+      yield {
+        ...result,
+        messages,
+        warningCount: 0,
+        fixableWarningCount: 0,
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ### Deprecate `CLIEngine` class
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -161,7 +161,7 @@ The following methods are removed because those don't fit the current API.
 
 Existing `getErrorResults()` method doesn't fit the new `executeOnFiles()` method because the result is an async iterator.
 
-The new `filterErrorResults()` method receives an `AsyncIterator<LintResult>` object and returns an `AsyncIterator<LintResult>` object. It extracts only the lint messages which are `severity === 2`, abandons the other messages.
+The new `filterErrorResults()` method receives an `AsyncIterator<LintResult>` object and returns an `AsyncIterator<LintResult>` object. It extracts only the lint messages which are `severity === 2` and abandons the other messages.
 
 <details>
 <summary>A rough sketch of the `filterErrorResults()` static method.</summary>

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -27,9 +27,9 @@ This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine
 - [static outputFixesInIteration()](#-the-outputfixesiniteration-method) (rename)
 - [static extractErrorResults()](#-the-extracterrorresults-method) (rename)
 - [getConfigForFile()](#-the-other-methods)
-- [getRules()](#-the-other-methods)
 - [isPathIgnored()](#-the-other-methods)
 - ~~addPlugin()~~ (move to a constructor option)
+- ~~getRules()~~ (delete)
 - ~~resolveFileGlobPatterns()~~ (delete)
 - [static compareResultsByFilePath()](#-new-methods) (new)
 
@@ -377,12 +377,12 @@ for await (const textPiece of formatter(results)) {
 The following methods return `Promise` which gets fulfilled with each result. Once we got this change, we can support ES modules for shareable configs, plugins, and custom parsers without more breaking changes.
 
 - `getConfigForFile()`
-- `getRules()`
 - `isPathIgnored()`
 
 The following methods are removed because those don't fit the new API.
 
 - `addPlugin()` ... This method has caused to confuse people. We have introduced this method to add plugin implementations and expected people to use this method to test plugins. But people have often thought that this method loads a new plugin for the following linting so they can use plugins rules without `plugins` setting. And this method is only one that mutates the state of `CLIEngine` objects and messes all caches. Therefore, this RFC moves this functionality to a constructor option. See also "[Constructor](#-constructor)" section.
+- `getRules()` ... This method returns the map that contains core rules and the rules of the plugin that the previous `executeOnFiles()` method call used. This behavior is surprised and forces us to store the config objects that the previous `executeOnFiles()` method call used. This proposal removes this method and a separated RFC (maybe [RFC47]) will add the successor.
 - `resolveFileGlobPatterns()` ... ESLint doesn't use this logic since `v6.0.0`, but it has stayed there for backward compatibility. Once [RFC20] is implemented, what ESLint iterates and what the glob of this method iterates will be different, then it will confuse users. This is good timing to remove the legacy.
 
 #### ● New methods
@@ -508,3 +508,4 @@ The access of the cache file finishes regardless of the progress of the iterator
 [rfc42]: https://github.com/eslint/rfcs/pull/42
 [rfc44]: https://github.com/eslint/rfcs/pull/44
 [rfc45]: https://github.com/eslint/rfcs/pull/45
+[rfc47]: https://github.com/eslint/rfcs/pull/47

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -27,9 +27,31 @@ This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine
 - `executeOnFiles()`
 - `executeOnText()`
 - `getConfigForFile()`
-- `getFormatter()`
 - `isPathIgnored()`
 - `outputFixes()`
+
+And the following method returns a `(results: LintReport, metadata: any) => stream.Readable`.
+
+- `getFormatter()`
+
+<details>
+
+```js
+    getFormatter(name) {
+        const formatter = cliEngine.getFormatter(name)
+        return (...args) => {
+            const text = formatter(...args)
+            const s = new stream.PassThrough()
+            process.nextTick(() => {
+                s.write(text)
+                s.end()
+            })
+            return s
+        }
+    }
+```
+
+</details>
 
 The following methods are as-is because those don't touch both file system and module system.
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -432,6 +432,7 @@ The new API depends on [Asynchronous Iteration](https://github.com/tc39/proposal
 - https://github.com/eslint/eslint/issues/1098 - Show results for each file as eslint is running
 - https://github.com/eslint/eslint/issues/3565 - Lint multiple files in parallel
 - https://github.com/eslint/eslint/issues/10272 - Validate options passed to CLIEngine API
+- https://github.com/eslint/eslint/issues/10606 - Make CLIEngine and supporting functions async via Promises
 - https://github.com/eslint/eslint/issues/12319 - `ERR_REQUIRE_ESM` when requiring `.eslintrc.js`
 - https://github.com/eslint/rfcs/pull/4 - New: added draft for async/parallel proposal
 - https://github.com/eslint/rfcs/pull/11 - New: Lint files in parallel

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -24,7 +24,7 @@ Initially the `ESLint` class will be a wrapper around `CLIEngine`, modifying ret
 
 #### § Constructor
 
-The constructor has the most same arguments as `CLIEngine`, but there are small differences.
+The constructor has mostly the same options as `CLIEngine`, but with some small differences:
 
 - It throws fatal errors if the options contain unknown properties or an option is invalid type ([eslint/eslint#10272](https://github.com/eslint/eslint/issues/10272)).
 - It disallows the deprecated `cacheFile` option.

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -1,0 +1,74 @@
+- Start Date: 2019-09-28
+- RFC PR: (leave this empty, to be filled in later)
+- Authors: Toru Nagashima ([@mysticatea](https://github.com/mysticatea))
+
+# Moving to Asynchronous API
+
+## Summary
+
+This RFC changes the methods of `CLIEngine` class returning `Promise` and adds `CLIEngineSync` class for soft-migration.
+
+## Motivation
+
+- Dynamic loading of ES modules requires asynchronous API. Migrating to asynchronous API opens up doors to write plugins/configs with ES modules.
+- Linting in parallel requires asynchronous API. We can improve linting logic to run it in parallel. And we can improve config loading logic and file enumeration logic to run it in parallel. (E.g., load `extends` list, traverse child directories.)
+
+## Detailed Design
+
+### Change the methods of `CLIEngine` class
+
+This RFC changes the following methods as returning `Promise`.
+
+- `executeOnFiles()`
+- `executeOnText()`
+- `getConfigForFile()`
+- `getFormatter()`
+- `isPathIgnored()`
+- `outputFixes()`
+
+The following methods are as-is because those don't touch both file system and module system.
+
+- `addPlugin()`
+- `getErrorResults()`
+- `getRules()`
+- `resolveFileGlobPatterns()`
+
+### Add `CLIEngineSync` class
+
+This RFC adds a new public class `CLIEngineSync` for soft-migration. The `CLIEngineSync` class has the completely same interface as the current `CLIEngine`.
+
+### Deprecate `CLIEngineSync` class
+
+This RFC soft-deprecates the new public class `CLIEngineSync`.
+
+Because it's tough to maintain two versions (sync and async) of implementation. The two are almost copy-pasted stuff, but hard to share the code. Therefore, this RFC deprecates the sync version to improve our code with the way which needs asynchronous behavior in the future. For example, `CLIEngineSync` cannot support parallel linting, plugins/configs as ES modules, etc...
+
+### Out of scope
+
+- Not change API for rules. This RFC doesn't change APIs that rule implementation uses. We may be able to support asynchronous stuff in rules in the future, but it's out of this RFC's scope.
+- Not change internal logics. This RFC just changes the public interface. The internal logic is still synchronous.
+
+## Documentation
+
+- This change needs the entry in the migration guide because of a breaking change.
+- The "[Node.js API](https://eslint.org/docs/developer-guide/nodejs-api)" page should describe the new public API.
+
+## Drawbacks
+
+People that use `CLIEngine` have to update their application with the new asynchronous API. This may be hard work.
+
+## Backwards Compatibility Analysis
+
+Yes, this is a drastic breaking change. New `CLIEngineSync` class is for soft-migration.
+
+## Alternatives
+
+- Adding `engine.executeAsyncOnFiles()`-like methods rather than changing existing methods.
+- Adding new `CLIEngineAsync`-like class that has async API rather than we move the existing APIs to `CLIEngineSync`.
+
+## Related Discussions
+
+- https://github.com/eslint/eslint/issues/3565 - Lint multiple files in parallel
+- https://github.com/eslint/eslint/issues/12319 - `ERR_REQUIRE_ESM` when requiring `.eslintrc.js`
+- https://github.com/eslint/rfcs/pull/4 - New: added draft for async/parallel proposal
+- https://github.com/eslint/rfcs/pull/11 - New: Lint files in parallel

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -10,7 +10,7 @@ This RFC adds a new class `LinterShell` that provides asynchronous API and depre
 
 ## Motivation
 
-- We have functionality that cannot be supported with the current synchronous API. For example, ESLint verifying files in parallel, formatters printing progress state, formatters printing results in streams etc. A move to an asynchronous API would be beneficial and a new `LinterShell` class can be created with an async API in mind from the start.
+- We have functionality that cannot be supported with the current synchronous API. For example, ESLint verifying files in parallel. A move to an asynchronous API would be beneficial and a new `LinterShell` class can be created with an async API in mind from the start.
 - Node.js has supported [ES modules](https://nodejs.org/api/esm.html) stably since `13.2.0`. Because Node.js doesn't provide any way that loads ES modules synchronously from CJS, ESLint cannot load configs/plugins that are written as ES modules. And migrating to asynchronous API opens up doors to support those.
 - The name of `CLIEngine`, our primary API, has caused confusion in the community and is sub-optimal. We have a lot of issues that say "please use `CLIEngine` instead.". A new class, `LinterShell`, while fixing other issues, will also make our primary API more clear.
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -188,6 +188,28 @@ class ESLint {
 
 </details>
 
+<details>
+<summary>Example: Use `filterErrorResults()`.</summary>
+
+```js
+const { ESLint } = require("eslint")
+const eslint = new ESLint()
+const formatter = eslint.getFormatter("stylish")
+
+// Verify files
+let results = eslint.executeOnFiles(patterns)
+// Filter the results if needed
+if (process.argv.includes("--quiet")) {
+    results = ESLint.filterErrorResults(results)
+}
+// Format and write the results
+for await (const textPiece of formatter(results)) {
+    process.stdout.write(textPiece)
+}
+```
+
+</details>
+
 ### Deprecate `CLIEngine` class
 
 This RFC soft-deprecates `CLIEngine` class.

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -29,7 +29,7 @@ This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine
 - [getConfigForFile()](#-the-other-methods)
 - [getRules()](#-the-other-methods)
 - [isPathIgnored()](#-the-other-methods)
-- ~~addPlugin()~~ (delete)
+- ~~addPlugin()~~ (move to a constructor option)
 - ~~resolveFileGlobPatterns()~~ (delete)
 - [static collectResults()](#-new-methods) (new)
 - [static compareResultsByFilePath()](#-new-methods) (new)

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -41,7 +41,7 @@ The constructor has mostly the same options as `CLIEngine`, but with some differ
 
 - It throws fatal errors if the options contain unknown properties or an option is invalid type ([eslint/eslint#10272](https://github.com/eslint/eslint/issues/10272)).
 - It disallows the deprecated `cacheFile` option.
-- It has a new `pluginImplementations` option as the successor of `addPlugin()` method. This is an object that keys are plugin IDs and each value is the plugin object. See also "[The other methods](#-the-other-methods)" section.
+- The array of the `plugins` option can contain objects `{ id: string; definition: Object }` along with strings. If the objects are present, the `id` property is the plugin ID and the `definition` property is the definition of the plugin. This is the successor of `addPlugin()` method. See also "[The other methods](#-the-other-methods)" section.
 
 <details>
 <summary>A rough sketch of the constructor.</summary>
@@ -66,7 +66,6 @@ class ESLint {
     ignorePattern = [],
     parser = "espree",
     parserOptions = null,
-    pluginImplementations = null,
     plugins = [],
     reportUnusedDisableDirectives = false,
     resolvePluginsRelativeTo = cwd,
@@ -107,7 +106,7 @@ class ESLint {
       ignorePattern,
       parser,
       parserOptions,
-      plugins,
+      plugins: plugins.map(p => (typeof p === "string" ? p : p.id)),
       reportUnusedDisableDirectives,
       resolvePluginsRelativeTo,
       rulePaths,
@@ -115,14 +114,32 @@ class ESLint {
       useEslintrc,
     }))
 
-    // Apply `pluginImplementations` option.
-    if (pluginImplementations) {
-      for (const [id, definition] of Object.entries(pluginImplementations)) {
-        engine.addPlugin(id, definition)
+    // Add the definitions of the `plugins` option.
+    if (plugins) {
+      for (const plugin of plugins) {
+        if (typeof plugin === "object" && plugin !== null) {
+          engine.addPlugin(plugin.id, plugin.definition)
+        }
       }
     }
   }
 }
+```
+
+</details>
+
+<details>
+<summary>For `plugins` example.</summary>
+
+```js
+const { ESLint } = require("eslint")
+const eslint = new ESLint({
+  plugins: [
+    "foo",
+    "eslint-plugin-bar",
+    { id: "abc", definition: require("./path/to/a-plugin") },
+  ],
+})
 ```
 
 </details>

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -12,7 +12,7 @@ This RFC adds a new class `ESLint` that has asynchronous API and deprecates `CLI
 
 - We have functionality that cannot be supported with the current synchronous API. For example, ESLint verifying files in parallel, formatters printing progress state, formatters printing results in streams etc. A move to an asynchronous API would be beneficial and a new `ESLint` class can be created with an async API in mind from the start.
 - Dynamic `import()` has arrived at Stage 4. The dynamic loading of ES modules requires asynchronous API. Migrating to asynchronous API opens up doors to write plugins/configs with ES modules.
-- The name of `CLIEngine`, our primary API, has caused confusion to the community. People try `Linter` class at first because the name sounds the main class of ESLint, then they notice it doesn't work as expected. We have a lot of issues that say "please use `CLIEngine` instead." The name of the new class, `ESLint`, is our primary API clearly.
+- The name of `CLIEngine`, our primary API, has caused confusion in the community and is sub-optimal. We have a lot of issues that say "please use `CLIEngine` instead.". A new class, `ESLint`, while fixing other issues, will also make our primary API more clear.
 
 ## Detailed Design
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -190,7 +190,10 @@ Because this method updates the cache file, it will break of called multiple tim
 
 The iterator protocol has optional [`return()` method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return) that forces to finish the iterator. The `for-of`/`for-await-of` syntax calls the `return()` method automatically if the loop is stopped through a `braek`, `return`, or `throw`.
 
-ESLint aborts linting when the `return()` method is called. For example, it will terminate all workers if [RFC42](https://github.com/eslint/rfcs/pull/42) is implemented.
+ESLint aborts linting when the `return()` method is called. The abort does:
+
+- ESLint updates the cache file with the current state when the `return()` method is first called. Therefore, the next time, ESLint can use the cache of the already linted files and lint only the canceled files.
+- ESLint will terminate all workers if [RFC42](https://github.com/eslint/rfcs/pull/42) is implemented.
 
 ```js
 const { ESLint } = require("eslint")

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -30,7 +30,7 @@ This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine
 - `isPathIgnored()`
 - `outputFixes()`
 
-And the following method returns a `(results: LintReport, metadata: any) => stream.Readable`.
+And the following method returns a `Promise<(results: LintReport, metadata: any) => stream.Readable>`.
 
 - `getFormatter()`
 
@@ -39,7 +39,7 @@ And the following method returns a `(results: LintReport, metadata: any) => stre
 ```js
     getFormatter(name) {
         const formatter = cliEngine.getFormatter(name)
-        return (...args) => {
+        return Promise.resolve((...args) => {
             const text = formatter(...args)
             const s = new stream.PassThrough()
             process.nextTick(() => {
@@ -47,7 +47,7 @@ And the following method returns a `(results: LintReport, metadata: any) => stre
                 s.end()
             })
             return s
-        }
+        })
     }
 ```
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -240,6 +240,7 @@ The new API depends on [Asynchronous Iteration](https://github.com/tc39/proposal
 ## Alternatives
 
 - Adding `engine.executeAsyncOnFiles()`-like methods and we maintain it along with the existing synchronous API. But as what I wrote in the "[Deprecate `CLIEngine` class](#deprecate-cliengine-class)" section, it would be tough.
+- Using [Streams](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html) instead of [Asynchronous Iteration](https://github.com/tc39/proposal-async-iteration). We can introduce `ESLint` class in a minor release if we used Streams. But because Node.js 8 will be EOL two months later, we should be able to use Asynchronous Iteration soon. Iterator protocol is smaller spec than streams, and it's easy to use.
 
 ## Related Discussions
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -209,9 +209,11 @@ People that use `CLIEngine` have to update their application with the new API. I
 
 ## Backwards Compatibility Analysis
 
-Deprecating `CLIEngine` is a drastic change. But people can continue to use `CLIEngine` as-is until we decide to remove it. The decision would not be near future.
+This is a breaking change.
 
-We can do both adding a new class and the deprecation in a minor release.
+Deprecating `CLIEngine` is a drastic change. But people can continue to use `CLIEngine` as-is until we decide to remove it.
+
+The new API depends on [Asynchronous Iteration](https://github.com/tc39/proposal-async-iteration) syntax. Node.js supports the syntax since `10.0.0`, so we have to drop Node.js `8.x`. Because the `8.x` will be EOL in December 2019 (two months later!), we can work on this soon.
 
 ## Alternatives
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -10,7 +10,7 @@ This RFC adds a new class `ESLint` that has asynchronous API and deprecates `CLI
 
 ## Motivation
 
-- We have the functionality that we cannot support with synchronous API. For example, ESLint verifies files in parallel, formatters print progress state, or formatters print results in streaming.
+- We have functionality that cannot be supported with the current synchronous API. For example, ESLint verifying files in parallel, formatters printing progress state, formatters printing results in streams etc. A move to an asynchronous API would be beneficial and a new `ESLint` class can be created with an async API in mind from the start.
 - Dynamic `import()` has arrived at Stage 4. The dynamic loading of ES modules requires asynchronous API. Migrating to asynchronous API opens up doors to write plugins/configs with ES modules.
 - The name of `CLIEngine`, our primary API, has caused confusion to the community. People try `Linter` class at first because the name sounds the main class of ESLint, then they notice it doesn't work as expected. We have a lot of issues that say "please use `CLIEngine` instead." The name of the new class, `ESLint`, is our primary API clearly.
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -162,7 +162,7 @@ As a side-effect, formatters gets the capability to print the used deprecated ru
 
 ##### Fail-fast on parallel calling
 
-Because this method updates the cache file, if people call this method in parallel then it causes broken. To prevent the broken, it should throw an error if people called this method while the previous call is still running.
+Because this method updates the cache file, it will break of called multiple times in parallel. To prevent that, it should throw an error if the method is called while a previous call is still running.
 
 ##### Abort linting
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -11,7 +11,7 @@ This RFC adds a new class `ESLint` that provides asynchronous API and deprecates
 ## Motivation
 
 - We have functionality that cannot be supported with the current synchronous API. For example, ESLint verifying files in parallel, formatters printing progress state, formatters printing results in streams etc. A move to an asynchronous API would be beneficial and a new `ESLint` class can be created with an async API in mind from the start.
-- Node.js will support [ES modules](https://nodejs.org/api/esm.html) stably on `13.0.0` at last. Node.js doesn't provide any way that loads ES modules synchronously from CJS. This means that ESLint (CJS) cannot load configs/plugins that are written as ES modules synchronously. Migrating to asynchronous API opens up doors to support those.
+- Node.js has supported [ES modules](https://nodejs.org/api/esm.html) stably since `13.2.0`. Because Node.js doesn't provide any way that loads ES modules synchronously from CJS, ESLint cannot load configs/plugins that are written as ES modules. And migrating to asynchronous API opens up doors to support those.
 - The name of `CLIEngine`, our primary API, has caused confusion in the community and is sub-optimal. We have a lot of issues that say "please use `CLIEngine` instead.". A new class, `ESLint`, while fixing other issues, will also make our primary API more clear.
 
 ## Detailed Design

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -384,7 +384,7 @@ The following methods are removed because those don't fit the new API.
 This RFC soft-deprecates `CLIEngine` class. Because:
 
 - It's tough to maintain two versions (sync and async) of implementation. The two are almost copy-pasted stuff, but hard to share the code. We can freeze the synchronous version of code by deprecation.
-- In the future, `CLIEngine` get not-supported features such as [RFC42], [RFC45], ES modules, etc because of synchronous API. This difference may be surprising for API users, but we can explain that as "Because `CLIEngine` has been deprecated, we don't add any new features into that class."
+- In the future, `CLIEngine` get not-supported features such as [RFC42], ES modules, etc because of synchronous API. This difference may be surprising for API users, but we can explain that as "Because `CLIEngine` has been deprecated, we don't add any new features into that class."
 
 ### ■ Out of scope
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -20,6 +20,16 @@ This RFC adds a new class `ESLint` that provides asynchronous API and deprecates
 
 This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine`, but the return value of some methods are different.
 
+- [constructor()](#-constructor)
+- [executeOnFiles()](#-the-executeonfiles-method)
+- [executeOnText()](#-the-executeontext-method)
+- [getFormatter()](#-the-getformatter-method)
+- [static outputFixesInIteration()](#-the-outputfixesiniteration-method) (rename)
+- [getConfigForFile()](#-the-other-methods)
+- [getRules()](#-the-other-methods)
+- [isPathIgnored()](#-the-other-methods)
+- [static compareResultsByFilePath()](#-new-methods) (new)
+
 Initially the `ESLint` class will be a wrapper around `CLIEngine`, modifying return types. Later it can take on a more independent shape as `CLIEngine` gets more deprecated.
 
 #### ● Constructor

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -70,6 +70,25 @@ As a side-effect, formatters gets the capability to print the used deprecated ru
 
 Because this method updates the cache file, if people call this method in parallel then it causes broken. To prevent the broken, it should throw an error if people called this method while the previous call is still running.
 
+##### Abort linting
+
+The iterator has optional [`return()` method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return). The `for-of`/`for-await-of` syntax calls the `return()` method automatically if the execution escaped from the loop by `braek`, `return`, or `throw`. In short, the `return()` method will be called when aborted.
+
+Therefore, ESLint aborts linting when the `return()` method is called. This will mean that the `return()` method terminates all workers once we implement parallel linting.
+
+```js
+const { ESLint } = require("eslint")
+const eslint = new ESLint()
+
+for await (const result of eslint.executeOnFiles(patterns)) {
+  if (Math.random() < 0.5) {
+    break // abort linting.
+  }
+}
+```
+
+And it throws an error if you reuse the aborted results.
+
 ##### Implementation
 
 <details>

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -20,7 +20,7 @@ This RFC adds a new class `ESLint` that has asynchronous API and deprecates `CLI
 
 This RFC adds a new class `ESLint`. It has almost the same methods as `CLIEngine`, but the return value of some methods are different.
 
-So, for now, `ESLint` class will be a tiny wrapper of `CLIEngine` that modifies the type of the return values.
+Initially the `ESLint` class will be a wrapper around `CLIEngine`, modifying return types. Later it can take on a more independent shape as `CLIEngine` gets more deprecated.
 
 #### § Constructor
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -53,7 +53,7 @@ Either way, we can support "linting in parallel", loading configs/plugins with `
 
 ##### Move the `usedDeprecatedRules` property
 
-The returned object of `CLIEngine#executeOnFiles()` has the `usedDeprecatedRules` property that includes the deprecated rule IDs which the linting used. But the location doesn't fit the use with `for-await-of` statement. Therefore, this RFC mvoes the `usedDeprecatedRules` property to each lint result.
+The returned object of `CLIEngine#executeOnFiles()` has the `usedDeprecatedRules` property that includes the deprecated rule IDs which the linting used. But the location doesn't fit the use with `for-await-of` statement. Therefore, this RFC moves the `usedDeprecatedRules` property to each lint result.
 
 ```js
 const { ESLint } = require("eslint")

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -80,6 +80,8 @@ print(results)
 
 Once the `executeOnFiles()` method got this change, we can support "linting in parallel", streaming, and plugins/configs which are ES modules in the future.
 
+⚠️ Because this method updates the cache file, if people call this method in parallel then it causes broken. To prevent the broken, it should throw an error if people called this method while the previous call is still running.
+
 #### § The `getFormatter()` method
 
 This method returns a `Promise<Formatter>`. The `Formatter` type is a function `(results: AsyncIterator<LintResult>) => AsyncIterator<string>`. It receives lint results then outputs the formatted text.

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -332,7 +332,6 @@ class LinterShell {
 
 Once we got this change, we can realize the following things:
 
-- (no RFC yet) We can support to print progress state.
 - (no RFC yet) We can support ES modules for custom formatters.
 
 #### ● The other methods
@@ -441,9 +440,9 @@ are alternatives. Both cases stop the previous or current call. It may be surpri
 
 - Waiting the previous call internally.
 
-The access of the cache file finishes regardless of the progress of the iterator that the method returned. It means that API users cannot know when the file access finished. On the other hand, because `LinterShell` objects know when the file access finished, it can execute the next call at the proper timing.
+It will work fine in a thread. However, the `LinterShell` objects cannot know the existence of other threads and processes that write the cache file.
 
-However, the `LinterShell` objects cannot know the existence of other threads and processes that write the cache file. The current way has a smaller risk than the alternatives.
+The current way has a smaller risk than the alternatives.
 
 ## Related Discussions
 
@@ -464,6 +463,4 @@ However, the `LinterShell` objects cannot know the existence of other threads an
 [rfc11]: https://github.com/eslint/rfcs/pull/11
 [rfc20]: https://github.com/eslint/rfcs/tree/master/designs/2019-additional-lint-targets
 [rfc42]: https://github.com/eslint/rfcs/pull/42
-[rfc44]: https://github.com/eslint/rfcs/pull/44
-[rfc45]: https://github.com/eslint/rfcs/pull/45
 [rfc47]: https://github.com/eslint/rfcs/pull/47

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -1,5 +1,5 @@
 - Start Date: 2019-09-28
-- RFC PR: (leave this empty, to be filled in later)
+- RFC PR: https://github.com/eslint/rfcs/pull/40
 - Authors: Toru Nagashima ([@mysticatea](https://github.com/mysticatea))
 
 # Moving to Asynchronous API

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -241,7 +241,7 @@ This method returns a Promise object that will be fulfilled with the array of li
 
 This method corresponds to `CLIEngine#executeOnText()`.
 
-Because the returned object of `CLIEngine#executeOnText()` method is the same type as the `CLIEngine#executeOnFiles()` method, the `LinterShell` class inherits that mannar. Therefore, the returned value is an array that contains one result.
+Because the returned object of `CLIEngine#executeOnText()` method is the same type as the `CLIEngine#executeOnFiles()` method, the `LinterShell` class also returns the same type. Therefore, the returned value is an array that contains one result.
 
 ```js
 const { LinterShell } = require("eslint")

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -347,7 +347,7 @@ The following methods return `Promise` which gets fulfilled with each result in 
 - `getConfigForFile()`
 - `isPathIgnored()`
 
-The following method is as-is because those don't touch both file system and module system.
+The following method is as-is because they touch neither file system or module system.
 
 - `getRules()`
 

--- a/designs/2019-move-to-async-api/README.md
+++ b/designs/2019-move-to-async-api/README.md
@@ -24,7 +24,7 @@ So, for now, `ESLint` class will be a tiny wrapper of `CLIEngine` that modifies 
 
 #### § The `executeOnFiles()` method
 
-This method returns an object that has two properties two methods `then()` and `[Symbol.asyncIterator]()`, and we can use the returned object with `await` expression and `for-await-of` statement.
+This method returns an object that has two methods `then()` and `[Symbol.asyncIterator]()`, so we can use the returned object with `await` expression and `for-await-of` statement.
 
 - If you used the returned object with `for-await-of` statement, it iterates the lint result of each file in random order. This way yields each lint result immediately. Therefore you can print the results in streaming, or print progress state. ESLint may spend time to lint files (for example, ESLint needs about 20 seconds to lint our codebase), to print progress state will be useful.
 


### PR DESCRIPTION
- [Rendered RFC](https://github.com/eslint/rfcs/blob/move-to-async-api/designs/2019-move-to-async-api/README.md)
- ~~Blocked by #44.~~ (merged)

## Summary

~~This RFC changes the methods of `CLIEngine` class as returning `Promise` and adds `CLIEngineSync` class for soft-migration.~~

This RFC adds a new class `LinterShell` that provides asynchronous API and deprecates `CLIEngine`.

## Related Issues

- https://github.com/eslint/eslint/issues/1098 - Show results for each file as eslint is running
- https://github.com/eslint/eslint/issues/3565 - Lint multiple files in parallel
- https://github.com/eslint/eslint/issues/10272 - Validate options passed to CLIEngine API
- https://github.com/eslint/eslint/issues/10606 - Make CLIEngine and supporting functions async via Promises
- https://github.com/eslint/eslint/issues/12319 - `ERR_REQUIRE_ESM` when requiring `.eslintrc.js`
- https://github.com/eslint/rfcs/pull/4 - New: added draft for async/parallel proposal
- https://github.com/eslint/rfcs/pull/11 - New: Lint files in parallel
- https://github.com/eslint/rfcs/pull/42 - New: Lint files in parallel if many files exist
- https://github.com/eslint/rfcs/pull/44 - New: Drop supports for Node.js 8.x and 11.x
- https://github.com/eslint/rfcs/pull/45 - New: Formatter v2
