### PR TITLE
  Docs: add repo info in template file

### DIFF
--- a/templates/design.md
+++ b/templates/design.md
@@ -1,3 +1,4 @@
+- Repo: (the repo it will be implemented in, e.g. eslint/espree)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty, to be filled in later)
 - Authors: (the names of everyone contributing to this RFC)


### PR DESCRIPTION
<del>
Presently it is hard to say what rfcs has been implemented. To better track the implementation, the PR update the rfc lifecycle:
1. "Approval" label means consensus has been reached;
2. "merged" means its implementation has been merged to ESLint codebase;


or we can add the  PR link of implementation to every rfc ?
</del>