### PR TITLE
Update: Tweet actions for RFCs

### DIFF
--- a/.github/workflows/tweet-rfc-update.yml
+++ b/.github/workflows/tweet-rfc-update.yml
@@ -2,7 +2,7 @@ name: Tweet RFC Update
 on:
   # Can't use pull_request because it won't have access to secrets
   pull_request_target:
-    types: [labeled, merged]
+    types: [labeled, closed]
 jobs:
   tweetStateChange:
     runs-on: ubuntu-latest

--- a/.github/workflows/tweet-rfc-update.yml
+++ b/.github/workflows/tweet-rfc-update.yml
@@ -1,16 +1,31 @@
 name: Tweet RFC Update
 on:
-  pull_request:
-    types: [labeled]
+  # Can't use pull_request because it won't have access to secrets
+  pull_request_target:
+    types: [labeled, merged]
 jobs:
-  tweet:
+  tweetStateChange:
     runs-on: ubuntu-latest
-    if: contains(github.event.label.name, 'Commenting')
+    if: github.event.action == 'labeled' && contains(github.event.label.name, 'Commenting')
     steps:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: 'npx @humanwhocodes/tweet "The RFC ${{ github.event.pull_request.title }} is now in the ${{ github.event.label.name }} phase.\n\n${{ github.event.pull_request.html_url }}"'
+      - run: npx @humanwhocodes/tweet "The RFC '${{ github.event.pull_request.title }}' is now in the ${{ github.event.label.name }} phase.\n\n${{ github.event.pull_request.html_url }}"
+        env:
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+
+  tweetMerge:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && github.event.pull_request.merged
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npx @humanwhocodes/tweet "The RFC '${{ github.event.pull_request.title }}' has been approved and merged!\n\n${{ github.event.pull_request.html_url }}"
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}


### PR DESCRIPTION
This fixes the tweet behavior in this repo based on the new `pull_request_target` event GitHub just introduced. This will allow the tweeting to work correctly.

I also added a tweet for when a pull request is merged. 

This hopefully means we won't need to do any manual tweeting when RFCs change states. :tada: