### PR TITLE
Update: separate eslint --init

### DIFF
--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -7,13 +7,13 @@
 
 ## Summary
 
-- Move the `init` command from main repo ([eslint](https://github.com/eslint/eslint)) to a new repo named `@eslint/create`.
+- Move the `init` command from main repo ([eslint](https://github.com/eslint/eslint)) to a new repo named `@eslint/create-config`.
 - Remove the auto-config.
 
 ## Motivation
 
 Currently the whole `init` command is being shipped with the cli in the main repo. Though its not that much of size (roughly ~0.6MB for the [eslint/lib/init](https://github.com/eslint/eslint/tree/master/lib/init)), this command is not a type of command that we need everyday or everytime running eslint. It is mainly used when creating a new project or adding eslint to a project for the first time. So if we move this to a separate package that is meant to use in the command line,
-We will make use of tools like `npx` to simply run `npx @eslint/create` or using `npm` to run `npm init @eslint` or using `yarn` to run `yarn create @eslint` single time for a project instead of having it in the core project.
+We will make use of tools like `npx` to simply run `npm init @eslint/config` or using `npm` to run `npx  @eslint/create-config` or using `yarn` to run `yarn create @eslint/config` single time for a project instead of having it in the core project.
 
 ## Detailed Design
 
@@ -26,7 +26,7 @@ We will make use of tools like `npx` to simply run `npx @eslint/create` or using
    used. Be sure to define any new terms in this section.
 -->
 
-The implementation is mainly migrating the code from main repo to `@eslint/create`.
+The implementation is mainly migrating the code from main repo to `@eslint/create-config`.
 
 The approach would be following these steps
 
@@ -57,7 +57,7 @@ The approach would be following these steps
   - `shelljs`
 
 It was almost done: [aladdin-add/eslint-create](https://github.com/aladdin-add/eslint-create).
-I will transfer the repo to the eslint group later.
+I will make a PR once the official repo is created later.
 
 ### Remove eslint auto-config
 
@@ -65,7 +65,7 @@ I will transfer the repo to the eslint group later.
 
 ### Update eslint cli usage
 
-- Whenever `--init` command is being used, show a warning(e.g. "You can also run this command directly using 'npm init @eslint'") and run `npx @eslint/create` using `child_process` of the native node modules.
+- Whenever `--init` command is being used, show a warning(e.g. "You can also run this command directly using 'npm init @eslint/config'") and run `npm init @eslint/config` using `child_process` of the native node modules.
 
 
 ## Documentation
@@ -75,7 +75,7 @@ I will transfer the repo to the eslint group later.
     on the ESLint blog to explain the motivation?
 -->
 
-- Documentation for `@eslint/create` will be created with proper usage and each prompt's details. In the main documentation, a link to `@eslint/create` will be given [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#--init) and basic usage and the package details will be documented.
+- Documentation for `@eslint/create-config` will be created with proper usage and each prompt's details. In the main documentation, a link to `@eslint/create-config` will be given [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#--init) and basic usage and the package details will be documented.
   Also in the cli command options, [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#options), for `--init` we need to change the description.
 - It is not a breaking change, so a formal announcement in not needed.
 
@@ -93,7 +93,7 @@ I will transfer the repo to the eslint group later.
 -->
 
 - This might increase the maintenance burden as this will add one more repo in the organization.
-- We may need to face challenges like re-directing of issues from `@eslint/create` repo to `eslint` and vice-versa.
+- We may need to face challenges like re-directing of issues from `@eslint/create-config` repo to `eslint` and vice-versa.
 
 ## Backwards Compatibility Analysis
 
@@ -130,10 +130,7 @@ The current implementation in `eslint` repo is the alternative. No changes neede
     you can remove this section.
 -->
 
-- Do we want to implement this as monorepo under `eslint` repo or a separate repo `@eslint/create` but github will make it as `eslint-create` or similar ?
+- Do we want to implement this as monorepo under `eslint` repo or a separate repo `@eslint/create-config` but github will make it as `create-config` or similar ?
 
   We decided not to go in the monorepo direction for this.
 
-- What should be the name of the package/repo?
-
-  We got a consensus on @eslint/create and eslint-create.

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -76,7 +76,7 @@ https://github.com/aladdin-add/eslint-create/blob/c27509cbbaea7c846fd9d7a373feec
 
 It can be removed after https://github.com/eslint/espree/issues/495 get landed.
 
-### 4. Rlease the new package
+### 4. Release the new package
 
 ### 5. Update eslint repo
 
@@ -151,4 +151,3 @@ The current implementation in `eslint` repo is the alternative. No changes neede
 - Do we want to implement this as monorepo under `eslint` repo or a separate repo `@eslint/create-config` but github will make it as `create-config` or similar ?
 
   We decided not to go in the monorepo direction for this.
-

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -1,0 +1,140 @@
+- Repo: [eslint/eslint](https://github.com/eslint/eslint)
+- Start Date: 2020-06-29
+- RFC PR:
+- Authors: Aniketh Saha ([anikethsaha](https://github.com/anikethsaha)) aladdin-add(weiran.zsd@outlook.com)
+
+# Move --init flag into a separate utility
+
+## Summary
+
+- Move the `init` command from main repo ([eslint](https://github.com/eslint/eslint)) to a new repo named `@eslint/create`.
+- Remove the auto-config.
+
+## Motivation
+
+Currently the whole `init` command is being shipped with the cli in the main repo. Though its not that much of size (roughly ~0.6MB for the [eslint/lib/init](https://github.com/eslint/eslint/tree/master/lib/init)), this command is not a type of command that we need everyday or everytime running eslint. It is mainly used when creating a new project or adding eslint to a project for the first time. So if we move this to a separate package that is meant to use in the command line,
+We will make use of tools like `npx` to simply run `npx @eslint/create` or using `npm` to run `npm init @eslint` or using `yarn` to run `yarn create @eslint` single time for a project instead of having it in the core project.
+
+## Detailed Design
+
+<!--
+   This is the bulk of the RFC.
+
+   Explain the design with enough detail that someone familiar with ESLint
+   can implement it by reading this document. Please get into specifics
+   of your approach, corner cases, and examples of how the change will be
+   used. Be sure to define any new terms in this section.
+-->
+
+The implementation is mainly migrating the code from main repo to `@eslint/create`. As far as the modules are concerned, all shared modules are being shipped currently with the eslint so we can use those modules through eslint itself.
+
+The approach would be following these steps
+
+### Move `eslint --init` related files to a separate repo
+
+- Move the `eslint/lib/init/*` to the new repo's `lib/*` directory
+- Add the following `dependencies` in `package.json`(the last 3 dependencies will be removed in next step)
+
+  - `enquirer`
+  - `progress`
+  - `semver`
+  - `lodash`
+  - `json-stable-stringify-without-jsonify`
+  - `cross-spawn`
+  - `debug`
+  - `@eslint/eslintrc` (to be removed)
+  - `eslint` (to be removed)
+  - `espree` (to be removed)
+
+- for all those modules coming inside `../**/*`, it would be replaced using `eslint/**/*`
+- For `tests`, move the `tests/lib/init` to new repo's `tests/init`
+- Add the following `devDependencies` in `package.json`
+
+  - `chai`
+  - `sinon`
+  - `js-yaml`
+  - `proxyquire`
+  - `shelljs`
+
+It was almost done: [aladdin-add/eslint-create](https://github.com/aladdin-add/eslint-create).
+I will transfer the repo to the eslint group later.
+
+### Remove eslint auto-config
+
+- Remove auto-config(`eslint/lib/init/autoconfig.js`), and its tests(`eslint/tests/lib/init/autoconfig.js`)
+
+### Update eslint cli usage
+
+- Whenever `--init` command is being used, show a warning(e.g. "You can also run this command directly using 'npm init @eslint'") and run `npx @eslint/create` using `child_process` of the native node modules.
+
+
+## Documentation
+
+<!--
+    How will this RFC be documented? Does it need a formal announcement
+    on the ESLint blog to explain the motivation?
+-->
+
+- Documentation for `@eslint/create` will be created with proper usage and each prompt's details. In the main documentation, a link to `@eslint/create` will be given [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#--init) and basic usage and the package details will be documented.
+  Also in the cli command options, [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#options), for `--init` we need to change the description.
+- It seems a breaking change to remove auto-config, a formal announcement needed?
+  This is a semver-minor change.
+
+## Drawbacks
+
+<!--
+    Why should we *not* do this? Consider why adding this into ESLint
+    might not benefit the project or the community. Attempt to think
+    about any opposing viewpoints that reviewers might bring up.
+
+    Any change has potential downsides, including increased maintenance
+    burden, incompatibility with other tools, breaking existing user
+    experience, etc. Try to identify as many potential problems with
+    implementing this RFC as possible.
+-->
+
+- This might increase the maintenance burden as this will add one more repo in the organization.
+- We may need to face challenges like re-directing of issues from `@eslint/create` repo to `eslint` and vice-versa.
+
+## Backwards Compatibility Analysis
+
+<!--
+    How does this change affect existing ESLint users? Will any behavior
+    change for them? If so, how are you going to minimize the disruption
+    to existing users?
+-->
+
+- Users can use `eslint --init`, which is as the same as current.
+- Users can no longer use auto-config.
+
+## Alternatives
+
+<!--
+    What other designs did you consider? Why did you decide against those?
+
+    This section should also include prior art, such as whether similar
+    projects have already implemented a similar feature.
+-->
+
+The current implementation in `eslint` repo is the alternative. No changes needed.
+
+## Open Questions
+
+<!--
+    This section is optional, but is suggested for a first draft.
+
+    What parts of this proposal are you unclear about? What do you
+    need to know before you can finalize this RFC?
+
+    List the questions that you'd like reviewers to focus on. When
+    you've received the answers and updated the design to reflect them,
+    you can remove this section.
+-->
+
+- Do we want to implement this as monorepo under `eslint` repo or a separate repo `@eslint/create` but github will make it as `eslint-create` or similar ?
+
+  We decided not to go in the monorepo direction for this.
+
+- What should be the name of the package/repo?
+
+  We got a consensus on @eslint/create and eslint-create.

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -69,7 +69,7 @@ I will make a PR once the official repo is created later.
 eslint was used:
 https://github.com/aladdin-add/eslint-create/blob/c27509cbbaea7c846fd9d7a373feece5254ac8d8/lib/config-file.js#L86
 
-It can be removed by using the local installed eslint, and switch to the new `Linter` api.
+It can be removed by using the local installed eslint, and switch to the new `ESLint` api.
 
 espree was used:
 https://github.com/aladdin-add/eslint-create/blob/c27509cbbaea7c846fd9d7a373feece5254ac8d8/lib/config-initializer.js#L161

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -1,6 +1,6 @@
 - Repo: [eslint/eslint](https://github.com/eslint/eslint)
 - Start Date: 2020-06-29
-- RFC PR:
+- RFC PR: https://github.com/eslint/rfcs/pull/79
 - Authors: Aniketh Saha ([anikethsaha](https://github.com/anikethsaha)) aladdin-add(weiran.zsd@outlook.com)
 
 # Move --init flag into a separate utility
@@ -26,7 +26,7 @@ We will make use of tools like `npx` to simply run `npx @eslint/create` or using
    used. Be sure to define any new terms in this section.
 -->
 
-The implementation is mainly migrating the code from main repo to `@eslint/create`. As far as the modules are concerned, all shared modules are being shipped currently with the eslint so we can use those modules through eslint itself.
+The implementation is mainly migrating the code from main repo to `@eslint/create`.
 
 The approach would be following these steps
 

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -13,7 +13,7 @@
 ## Motivation
 
 Currently the whole `init` command is being shipped with the cli in the main repo. Though its not that much of size (roughly ~0.6MB for the [eslint/lib/init](https://github.com/eslint/eslint/tree/master/lib/init)), this command is not a type of command that we need everyday or everytime running eslint. It is mainly used when creating a new project or adding eslint to a project for the first time. So if we move this to a separate package that is meant to use in the command line,
-We will make use of tools like `npx` to simply run `npm init @eslint/config` or using `npm` to run `npx  @eslint/create-config` or using `yarn` to run `yarn create @eslint/config` single time for a project instead of having it in the core project.
+We will make use of tools like `npm` to simply run `npm init @eslint/config` or using `npx` to run `npx  @eslint/create-config` or using `yarn` to run `yarn create @eslint/config` single time for a project instead of having it in the core project.
 
 ## Detailed Design
 

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -41,9 +41,7 @@ The approach would be following these steps
 - Add the following `dependencies` in `package.json`
 
   - `enquirer`
-  - `progress`
   - `semver`
-  - `lodash`
   - `json-stable-stringify-without-jsonify`
   - `cross-spawn`
   - `debug`

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -47,7 +47,7 @@ The approach would be following these steps
   - `espree` (to be removed)
 
 - for all those modules coming inside `../**/*`, it would be replaced using `eslint/**/*`
-- For `tests`, move the `tests/lib/init` to new repo's `tests/init`
+- For `tests`, move the `tests/lib/init` to new repo's `tests/lib/`
 - Add the following `devDependencies` in `package.json`
 
   - `chai`

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -77,8 +77,7 @@ I will transfer the repo to the eslint group later.
 
 - Documentation for `@eslint/create` will be created with proper usage and each prompt's details. In the main documentation, a link to `@eslint/create` will be given [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#--init) and basic usage and the package details will be documented.
   Also in the cli command options, [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#options), for `--init` we need to change the description.
-- It seems a breaking change to remove auto-config, a formal announcement needed?
-  This is a semver-minor change.
+- It is not a breaking change, so a formal announcement in not needed.
 
 ## Drawbacks
 

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -33,7 +33,7 @@ The approach would be following these steps
 ### Move `eslint --init` related files to a separate repo
 
 - Move the `eslint/lib/init/*` to the new repo's `lib/*` directory
-- Add the following `dependencies` in `package.json`(the last 3 dependencies will be removed in next step)
+- Add the following `dependencies` in `package.json`(the last 2 dependencies will be removed in next step)
 
   - `enquirer`
   - `progress`
@@ -42,7 +42,7 @@ The approach would be following these steps
   - `json-stable-stringify-without-jsonify`
   - `cross-spawn`
   - `debug`
-  - `@eslint/eslintrc` (to be removed)
+  - `@eslint/eslintrc`
   - `eslint` (to be removed)
   - `espree` (to be removed)
 

--- a/designs/2021-init-command-eslint-cli/README.md
+++ b/designs/2021-init-command-eslint-cli/README.md
@@ -7,8 +7,8 @@
 
 ## Summary
 
-- Move the `init` command from main repo ([eslint](https://github.com/eslint/eslint)) to a new repo named `@eslint/create-config`.
 - Remove the auto-config.
+- Move the `init` command from main repo ([eslint](https://github.com/eslint/eslint)) to a new repo named `@eslint/create-config`.
 
 ## Motivation
 
@@ -30,10 +30,15 @@ The implementation is mainly migrating the code from main repo to `@eslint/creat
 
 The approach would be following these steps
 
-### Move `eslint --init` related files to a separate repo
+### 1. Remove eslint auto-config
+
+- Remove auto-config(`eslint/lib/init/autoconfig.js`), and its tests(`eslint/tests/lib/init/autoconfig.js`).
+- Remove dependency `progress`, as it's no longer used in production.
+
+### 2. Move `eslint --init` related files to a separate repo
 
 - Move the `eslint/lib/init/*` to the new repo's `lib/*` directory
-- Add the following `dependencies` in `package.json`(the last 2 dependencies will be removed in next step)
+- Add the following `dependencies` in `package.json`
 
   - `enquirer`
   - `progress`
@@ -59,14 +64,27 @@ The approach would be following these steps
 It was almost done: [aladdin-add/eslint-create](https://github.com/aladdin-add/eslint-create).
 I will make a PR once the official repo is created later.
 
-### Remove eslint auto-config
+### 3. Remove the usage of eslint & espree
 
-- Remove auto-config(`eslint/lib/init/autoconfig.js`), and its tests(`eslint/tests/lib/init/autoconfig.js`)
+eslint was used:
+https://github.com/aladdin-add/eslint-create/blob/c27509cbbaea7c846fd9d7a373feece5254ac8d8/lib/config-file.js#L86
 
-### Update eslint cli usage
+It can be removed by using the local installed eslint, and switch to the new `Linter` api.
 
+espree was used:
+https://github.com/aladdin-add/eslint-create/blob/c27509cbbaea7c846fd9d7a373feece5254ac8d8/lib/config-initializer.js#L161
+
+It can be removed after https://github.com/eslint/espree/issues/495 get landed.
+
+### 4. Rlease the new package
+
+### 5. Update eslint repo
+
+- Remove `eslint --init` related files.
+- the following dependencies can be removed in eslint repo:
+  - enquirer
+  - semver
 - Whenever `--init` command is being used, show a warning(e.g. "You can also run this command directly using 'npm init @eslint/config'") and run `npm init @eslint/config` using `child_process` of the native node modules.
-
 
 ## Documentation
 
@@ -74,10 +92,10 @@ I will make a PR once the official repo is created later.
     How will this RFC be documented? Does it need a formal announcement
     on the ESLint blog to explain the motivation?
 -->
-
+- [get-started](https://eslint.org/docs/user-guide/getting-started).
 - Documentation for `@eslint/create-config` will be created with proper usage and each prompt's details. In the main documentation, a link to `@eslint/create-config` will be given [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#--init) and basic usage and the package details will be documented.
   Also in the cli command options, [here](https://github.com/eslint/eslint/blob/master/docs/user-guide/command-line-interface.md#options), for `--init` we need to change the description.
-- It is not a breaking change, so a formal announcement in not needed.
+- A formal announcement in not needed, as it is not a breaking change.
 
 ## Drawbacks
 


### PR DESCRIPTION
rendered: https://github.com/aladdin-add/rfcs/tree/init-command-eslint-cli/designs/2021-init-command-eslint-cli

## Summary

<!-- paste the summary from your proposal here -->
- Move the `init` command from main repo ([eslint](https://github.com/eslint/eslint)) to a new repo named `@eslint/create-config`.
- Remove the auto-config.
## Related Issues

<!-- optional: include links to relevant discussions here -->
this is following https://github.com/eslint/rfcs/pull/58
