### PR TITLE
ci: use `setup-node@v2` and node `v16`

### DIFF
--- a/.github/workflows/tweet-rfc-update.yml
+++ b/.github/workflows/tweet-rfc-update.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16.x'
       - run: npx @humanwhocodes/tweet 'The RFC "${{ github.event.pull_request.title }}" is now in the ${{ github.event.label.name }} phase.\n\n${{ github.event.pull_request.html_url }}'
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16.x'
       - run: npx @humanwhocodes/tweet 'The RFC "${{ github.event.pull_request.title }}" has been approved and merged!\n\n${{ github.event.pull_request.html_url }}'
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}

--- a/.github/workflows/tweet-rfc-update.yml
+++ b/.github/workflows/tweet-rfc-update.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'labeled' && contains(github.event.label.name, 'Commenting')
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
       - run: npx @humanwhocodes/tweet 'The RFC "${{ github.event.pull_request.title }}" is now in the ${{ github.event.label.name }} phase.\n\n${{ github.event.pull_request.html_url }}'
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'closed' && github.event.pull_request.merged
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
       - run: npx @humanwhocodes/tweet 'The RFC "${{ github.event.pull_request.title }}" has been approved and merged!\n\n${{ github.event.pull_request.html_url }}'
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}


### PR DESCRIPTION
## Summary

Update the `setup-node` action to `v2` for CI.

Use node LTS version (v16) for jobs on CI.

<!-- paste the summary from your proposal here -->

## Related Issues
None
<!-- optional: include links to relevant discussions here -->

