### PR TITLE
feat: ESLintRC Option To Forbid inline configuration For Specific Rules

### DIFF
--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -44,7 +44,7 @@ first in `getDirectiveComments` I will match any directives that affect a rule l
 
 This error will **not** have a quick fix available
 
-In `applyDirectives` (`apply-disable-directives.js`) I will reference the problem. If that problem matches a name in the array `noInlineConfig` I will not apply any directives. This will ensure that `problems.push(problem)` gets run. Note that this same logic applies to configuration comments as well. During this step, I will also ensure that the rule does not offer `disable` as a quick fix.
+In `applyDirectives` (`apply-disable-directives.js`) I will reference the problem. If that problem matches a name in the array `noInlineConfig` I will not apply any directives. This will ensure that `problems.push(problem)` gets run. Note that this same logic applies to configuration comments as well.
 
 ## Documentation
 
@@ -55,6 +55,8 @@ The main documentation [here](https://eslint.org/docs/user-guide/getting-started
 We will want to update the documentation for `noInlineConfig` to reference the similarities ([here](https://eslint.org/docs/user-guide/configuring/rules#disabling-inline-comments)).
 
 ## Drawbacks
+
+**Important:** This design will prevent a rule from being disabled. Which when applied to rules that have many edge cases, will mean that that rule cannot be disabled even when edge cases are found that Cannot be worked around. The only solution for those rules will be to change their severity back to error (losing out on the purpose of this RFC).
 
 this adds complexity to the already complex config experience.
 
@@ -96,6 +98,8 @@ Another alternative that requires 0 code is to encourage users to set up a secon
     - because PR reviewers are lazy.
 - Why can't users just change the config to get around this?
     - Most repos large enough where this is an issue have the config guarded behind a set of required reviewers that understand the config.
+- What will we do about VSCode suggesting disable as a workaround?
+    - the eslint vscode extension handles suggesting disable. So this would just be a known error until someone changes that behavior to match this RFC from the vscode extension side.
 ## Related Discussions
 
 - [Initial issues conversation](https://github.com/eslint/eslint/issues/15631)

--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -26,8 +26,6 @@ Is a much worse rule to disable than
 
 ## Detailed Design
 
-in `linter.js` I will adjust the `getDirectiveComments` function so that I reference a list of forbidden rules. If someone is disabling a rule that is forbidden. I will add an error similar to `warnInlineConfig`
-
 In `eslintrc` I will add another option for rules. The new state can be
 ```
 "warn"
@@ -36,9 +34,15 @@ In `eslintrc` I will add another option for rules. The new state can be
 ```
 where forbid is always an error and cannot be overridden by a directive
 
-I will add a new array called `forbiddenRules` that will be processed on initialization of the linter.js. This will happen in the Constructor. Then in `getDirectiveComments` I will reference the rule being disabled in the directive. If that rule matches a rule in `forbiddenRules` then I will not accept that directive. And I will declare an error on that string
+EG `// eslint-disable semi` will have ~~semi~~ as an error, as well as the violation also having an error.
 
-EG `// eslint-disable semi` will have ~~semi~~ as an error
+Both errors will have a severity of 2. See [LintMessage#severity](https://eslint.org/docs/developer-guide/nodejs-api#-lintmessage-type)
+
+I will add a new array to the linter called `forbiddenRules` that will be processed on initialization of the linter.js. This will happen in the Constructor. Then in `getDirectiveComments` I will reference the rule being disabled in the directive. If that rule matches a rule in `forbiddenRules` then I will not accept that directive. And I will declare an error on that string. Note that this same logic applies to configuration comments as well.
+
+in `linter.js` I will adjust the `getDirectiveComments` function so that I reference a list of forbidden rules. If someone is disabling a rule that is forbidden. I will add an error similar to `warnInlineConfig`
+
+note that when disabling all rules such as `/* eslint-disable */` the directive object will have `ruleId: null`. This will need a workaround. 
 
 This error will **not** have a quick fix available
 
@@ -96,7 +100,8 @@ Another alternative that requires 0 code is to encourage users to set up a secon
     Are you able to implement this RFC on your own? If not, what kind
     of help would you need from the team?
 -->
-I can implement this independently
+- I can implement this independently
+- Will the RFC still need to be open for 21 days if the main contributors all chime in?
 
 ## Frequently Asked Questions
 

--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -1,0 +1,132 @@
+- Repo: eslint/eslint
+- Start Date: 2022-02-28
+- RFC PR:
+- Authors: Brian Bartels
+
+# ESLintRC Option To Forbid Disable For Specific Rules
+
+## Summary
+
+Allow users to forbid users from disabling certain rules. This is similar to `noInlineConfig` where the primary difference is that `noInlineConfig` is set for all rules
+
+## Motivation
+
+When working with complex lint configs. Some rules are more important than other. For this reason it can be inconsequential to disable certain rules. But incredibly bad to disable others.
+
+EG:
+```
+//eslint-disable-next-line @government/required-SECURITY-rule
+```
+Is a much worse rule to disable than
+```
+//eslint-disable-next-line noExtraSemi
+```
+
+`noInlineConfig` works well for some. But in reality, many users disable rules at least somewhat frequently for valid reasons. And in large repos, there are going to be exceptions that need inline configuration. 
+
+## Detailed Design
+
+<!--
+   This is the bulk of the RFC.
+
+   Explain the design with enough detail that someone familiar with ESLint
+   can implement it by reading this document. Please get into specifics
+   of your approach, corner cases, and examples of how the change will be
+   used. Be sure to define any new terms in this section.
+-->
+in `linter.js` I will adjust the `getDirectiveComments` function so that I reference a list of forbidden rules. If someone is disabling a rule that is forbidden. I will add a warning (error?) similar to `warnInlineConfig`
+
+In `eslintrc` I will add another option for rules. The new state can be
+```
+warn
+error
+forbid
+```
+where forbid is always an error and cannot be overridden by a directive
+
+
+## Documentation
+
+<!--
+    How will this RFC be documented? Does it need a formal announcement
+    on the ESLint blog to explain the motivation?
+-->
+We will want to update the documentation to reflect the new changes
+
+## Drawbacks
+
+<!--
+    Why should we *not* do this? Consider why adding this into ESLint
+    might not benefit the project or the community. Attempt to think 
+    about any opposing viewpoints that reviewers might bring up. 
+
+    Any change has potential downsides, including increased maintenance
+    burden, incompatibility with other tools, breaking existing user
+    experience, etc. Try to identify as many potential problems with
+    implementing this RFC as possible.
+-->
+
+this adds complexity to the already complex eslintrc experience
+
+## Backwards Compatibility Analysis
+
+<!--
+    How does this change affect existing ESLint users? Will any behavior
+    change for them? If so, how are you going to minimize the disruption
+    to existing users?
+-->
+This should integrate into the planned eslintrc changes and therefore will not be backwards compatible.
+
+## Alternatives
+
+<!--
+    What other designs did you consider? Why did you decide against those?
+
+    This section should also include prior art, such as whether similar
+    projects have already implemented a similar feature.
+-->
+
+instead of adding a state to `error/warn` we could instead add another optional field to the rule config. This would enable a rule to be `warn` and have directives disabled. However, I believe that this actually adds more bloat to eslintrc which is why I chose the above design
+
+## Open Questions
+
+<!--
+    This section is optional, but is suggested for a first draft.
+
+    What parts of this proposal are you unclear about? What do you
+    need to know before you can finalize this RFC?
+
+    List the questions that you'd like reviewers to focus on. When
+    you've received the answers and updated the design to reflect them, 
+    you can remove this section.
+-->
+
+- How Can I gracefully integrate into the eslintrc updates
+
+## Help Needed
+
+<!--
+    This section is optional.
+
+    Are you able to implement this RFC on your own? If not, what kind
+    of help would you need from the team?
+-->
+
+## Frequently Asked Questions
+
+<!--
+    This section is optional but suggested.
+
+    Try to anticipate points of clarification that might be needed by
+    the people reviewing this RFC. Include those questions and answers
+    in this section.
+-->
+
+## Related Discussions
+
+<!--
+    This section is optional but suggested.
+
+    If there is an issue, pull request, or other URL that provides useful
+    context for this proposal, please include those links here.
+-->

--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -1,6 +1,6 @@
 - Repo: eslint/eslint
 - Start Date: 2022-02-28
-- RFC PR:
+- RFC PR: <https://github.com/eslint/rfcs/pull/86>
 - Authors: Brian Bartels
 
 # ESLintRC Option To Enable noInlineConfig For Specific Rules

--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -35,7 +35,7 @@ noInlineConfig: { type: ["boolean", "array"] },
 
 EG `// eslint-disable semi` will have ~~semi~~ as an error, as well as the violation that it is attempting to disable also having an error.
 
-Both errors will have a severity of 2. See [LintMessage#severity](https://eslint.org/docs/developer-guide/nodejs-api#-lintmessage-type)
+The error on the inline config will have a severity of 2. See [LintMessage#severity](https://eslint.org/docs/developer-guide/nodejs-api#-lintmessage-type)
 
 first in `getDirectiveComments` I will match any directives that affect a rule listed in the array `noInlineConfig`. If there is a match, I will create a problem on that line to alert the user that they are attempting to disable a rule that will not be affected by the inline config.
 

--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -3,11 +3,11 @@
 - RFC PR:
 - Authors: Brian Bartels
 
-# ESLintRC Option To Forbid Disable For Specific Rules
+# ESLintRC Option To Enable noInlineConfig For Specific Rules
 
 ## Summary
 
-Allow users to forbid users from disabling certain rules. This is similar to `noInlineConfig` where the primary difference is that `noInlineConfig` is set for all rules.
+Allow users to forbid users from configuring certain rules inline. This is an extension to `noInlineConfig` where the primary difference is that `noInlineConfig` currently is set for all rules.
 
 ## Motivation
 
@@ -22,48 +22,47 @@ Is a much worse rule to disable than
 //eslint-disable-next-line noExtraSemi
 ```
 
-`noInlineConfig` works well for some. But in reality, many users disable rules at least somewhat frequently for valid reasons. And in large repos, there are going to be exceptions that need inline configuration. 
+`noInlineConfig` currently works well for some. But in reality, many users disable rules at least somewhat frequently for valid reasons. And in large repos, there are going to be exceptions that need inline configuration. 
 
 ## Detailed Design
 
-In `eslintrc` I will add another option for rules. The new state can be
-```
-"warn"
-"error"
-"forbid"
-```
-where forbid is always an error and cannot be overridden by a directive
+I will add the option to pass `noInlineConfig` an array of rule names. This is in addition to the already supported boolean setting. This will result in those rules having inline configuration disabled.
 
-EG `// eslint-disable semi` will have ~~semi~~ as an error, as well as the violation also having an error.
+This means that I will need to modify `config-schema.js`
+```
+noInlineConfig: { type: ["boolean", "array"] },
+```
+
+EG `// eslint-disable semi` will have ~~semi~~ as an error, as well as the violation that it is attempting to disable also having an error.
 
 Both errors will have a severity of 2. See [LintMessage#severity](https://eslint.org/docs/developer-guide/nodejs-api#-lintmessage-type)
 
-I will add a new array to the linter called `forbiddenRules` that will be processed on initialization of the linter.js. This will happen in the Constructor. Then in `getDirectiveComments` I will reference the rule being disabled in the directive. If that rule matches a rule in `forbiddenRules` then I will not accept that directive. And I will declare an error on that string. Note that this same logic applies to configuration comments as well.
-
-in `linter.js` I will adjust the `getDirectiveComments` function so that I reference a list of forbidden rules. If someone is disabling a rule that is forbidden. I will add an error similar to `warnInlineConfig`
-
-note that when disabling all rules such as `/* eslint-disable */` the directive object will have `ruleId: null`. This will need a workaround. 
+first in `getDirectiveComments` I will match any directives that affect a rule listed in the array `noInlineConfig`. If there is a match, I will create a problem on that line to alert the user that they are attempting to disable a rule that will not be affected by the inline config.
 
 This error will **not** have a quick fix available
 
 
+In `applyDirectives` (`apply-disable-directives.js`) I will reference the problem. If that problem matches a name in the array `noInlineConfig` I will not apply any directives. This will ensure that `problems.push(problem)` gets run. Note that this same logic applies to configuration comments as well.
+
 ## Documentation
 
-We will want to update the documentation to reflect the new changes. The announcement can be integrated into the eslintrc update announcement.
+We will want to update the documentation ([here](https://eslint.org/docs/user-guide/configuring/rules#disabling-inline-comments)) to reflect the new changes. The announcement can be integrated into the config update announcement.
 
 ## Drawbacks
 
-this adds complexity to the already complex eslintrc experience. Users could be confused by the interaction with `forbid` and `noInlineConfig`.
+this adds complexity to the already complex config experience.
 
 This will have a very minor impact on perf.
 
+This design does not alert users in the case where they user `// eslint-disable` because that directive has `ruleId: null`. However, the design will still appropriately enforce the proper rules as desired.
+
 ## Backwards Compatibility Analysis
 
-This should integrate into the planned eslintrc changes and therefore will not be backwards compatible. However, this is acceptable since that will be a breaking change that is already approved and planned.
+This should integrate into the planned config changes and therefore will not be backwards compatible. However, this is acceptable since that will be a breaking change that is already approved and planned.
 
 ## Alternatives
 
-instead of adding a state to `error/warn` we could instead add another optional field to the rule config. This would enable a rule to be `warn` and have directives disabled. However, I believe that this actually adds more bloat to eslintrc which is why I chose the above design
+instead of extending `noInlineConfig` we could instead add a state called `enforce` to `error/warn`. This would be a superset of `error` where the rules cannot be disabled by inline config. However, it is hard to convey to the user succinctly what this accomplishes. And it allows users to disable the rules more easily in config files
 
 There are plugins such as [eslint-comments/no-restricted-disable](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-restricted-disable.html) that implement this concept. However, since these are just other rules, one can easily disable them. This results in scenarios such as
 
@@ -77,49 +76,18 @@ Another alternative that requires 0 code is to encourage users to set up a secon
 
 ## Open Questions
 
-<!--
-    This section is optional, but is suggested for a first draft.
-
-    What parts of this proposal are you unclear about? What do you
-    need to know before you can finalize this RFC?
-
-    List the questions that you'd like reviewers to focus on. When
-    you've received the answers and updated the design to reflect them, 
-    you can remove this section.
--->
-
-- How can I gracefully integrate into the eslintrc updates?
+- How can I gracefully integrate into the config updates?
 - How can I test runtime to ensure that this doesn't affect perf?
 - What is the testing strategy that ESLint community prefers?
 
 ## Help Needed
 
-<!--
-    This section is optional.
-
-    Are you able to implement this RFC on your own? If not, what kind
-    of help would you need from the team?
--->
 - I can implement this independently
-- Will the RFC still need to be open for 21 days if the main contributors all chime in?
 
 ## Frequently Asked Questions
 
-<!--
-    This section is optional but suggested.
-
-    Try to anticipate points of clarification that might be needed by
-    the people reviewing this RFC. Include those questions and answers
-    in this section.
--->
 - Why do PR approvers approve PRs with `no-eslint-disable` rule?
     - because PR reviewers are lazy.
 ## Related Discussions
 
-<!--
-    This section is optional but suggested.
-
-    If there is an issue, pull request, or other URL that provides useful
-    context for this proposal, please include those links here.
--->
 - [Initial issues conversation](https://github.com/eslint/eslint/issues/15631)

--- a/designs/2022-forbid-disable/README.md
+++ b/designs/2022-forbid-disable/README.md
@@ -54,7 +54,7 @@ this adds complexity to the already complex config experience.
 
 This will have a very minor impact on perf.
 
-This design does not alert users in the case where they user `// eslint-disable` because that directive has `ruleId: null`. However, the design will still appropriately enforce the proper rules as desired.
+This design does not alert users in the case where they use `// eslint-disable` because that directive has `ruleId: null`. However, the design will still appropriately enforce the proper rules as desired.
 
 ## Backwards Compatibility Analysis
 


### PR DESCRIPTION
## Summary

Allow users to forbid users from disabling certain rules. This is similar to `noInlineConfig` where the primary difference is that `noInlineConfig` is set for all rules.

## Related Issues

[Initial issues conversation](https://github.com/eslint/eslint/issues/15631)

