### PR TITLE
feat: create eslint-community GitHub organization

### DIFF
--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -48,12 +48,12 @@ maintained anymore and are given back to the community.
 > Community repos for ESLint related projects
 
 The benefit of having the org in place would be that the community isn't
-dependent on one person's GitHub/npm account.  
+dependent on one person's GitHub/`npm` account.  
 The added benefit is that the people maintaining the packages in the new org
 _could_ create a structure to streamline the packages more. They _could_ for
 instance decide things like using the same tools, supporting the same
 Node/ESLint versions, if we want to release all "rescued" packages under the
-`@eslint-community` npm scope or not, ...
+`@eslint-community` `npm` scope or not, ...
 
 As a reference, `@jest-community` has the following goal & intention:
 
@@ -63,7 +63,7 @@ As a reference, `@jest-community` has the following goal & intention:
 > dependent on one person's GitHub account in case they move on.
 
 The beauty of having a shared org is that the release process is centralised, so
-no need to talk to npm about an ownership transfer and no need to fork and
+no need to talk to `npm` about an ownership transfer and no need to fork and
 republish under a new name. Just appoint new maintainers on GitHub and they can
 work to restore continuity of service - a process which would be invisible to
 users (i.e. users might see a pause in updates but not have to make changes -
@@ -123,7 +123,7 @@ I personally think that the acceptance criteria for a package to go under the
 
 - It didn't receive an update in the last 12(?) months  
   I think we can make an exception for packages that did get a PR merged which
-  was created by a member of the new org's "core" team (mostly for updating
+  was created by a member of the community core team (mostly for updating
   compatibility with newer versions of ESLint).
 
   We can also make an exception for packages that meet the other criteria, but
@@ -135,41 +135,56 @@ I personally think that the acceptance criteria for a package to go under the
   if they would feel it would be better maintained by the community instead of
   putting all workload on their shoulders.
 
+- It should agree to the code of conduct of the org
+- It should have an OSI-approved license
+- `eslintbot` should be added as an owner to the original npm package
+
 If a package is meeting these criteria, but we can't get into contact with the
 owner of the repo to transfer ownership over to the new org, we could
-temporarily fork the repo & publish the package as
-`@eslint-community-fork/<package name>` or so.
+temporarily fork the repo into the new org. However, the ultimate goal would
+always be to transfer the original repo to the new org.  
+If we had a temporary fork, we should create PRs to the original repo to bring
+it up to date with the fork before continuing with other tasks.
 
 ### What permissions should maintainers have?
 
-I think it would be best to have some sort of a "core" team (of at least 3(?)
-people) that's making the decisions in terms of acceptance to the repo, which
-would (in addition to ESLint TSC) all be admin of the org.
+I think it would be best to have some sort of a community core team (of at least
+3(?) people) that's making the decisions in terms of acceptance to the repo,
+which would (in addition to ESLint TSC) all be admins of the org.
 
-We can make a team (with sub-teams if we want) for each package, where we give
-admin rights on the repo for that specific package.
+We can make a team (with sub-teams, if we want) for each package, where we give
+maintainer rights on the repo for that specific package, but keep admin rights
+to ESLint TSC & the community core team. This way we prevent that the repo would
+be destroyed from the org.
 
-The "core" team would help maintain all repos, whereas people in specific teams
-would only help maintain these repositories.
+We'll create a setup where we publish new versions of the package with
+`eslintbot`. That way we can keep publishing new versions if someone would
+dissapear.
 
-The "core" team would also be responsible to contact package maintainers
+The community core team would help maintain all repos, whereas people in
+specific teams would only help maintain these repositories.
+
+The community core team would be responsible of administer the Code of Conduct
+of the organization.
+
+The community core team would also be responsible to contact package maintainers
 (outside of GitHub) if they appear inactive. If the package maintainers don't
 respond in a reasonable time frame (npm gives you 14(?) days to respond to a
-transfer request email), they could be considered non-responsive and the "core"
-team can step in to appoint a new maintainer for the repository.
+transfer request email), they could be considered non-responsive and the
+community core team can step in to appoint a new maintainer for the repository.
 
 **Bonus:** I think having our own place in the Discord server where we can
 discuss some things would be a good idea as well.  
-This way the "core" team has an open place to discuss some common things like
-extracting common functionality into a separate package, minimum Node & ESLint
-target, how to handle disputes between maintainers, ...  
+This way the community core team has an open place to discuss some common things
+like extracting common functionality into a separate package, minimum Node &
+ESLint target, how to handle disputes between maintainers, ...  
 Having a channel for each separate package would maybe be a good idea as well,
 so the community has a change to ask questions to the maintainers as well.
 
 ### What should be the role of the ESLint team?
 
 The idea is that the ESLint team is the ultimate caretakers, they assign a
-"core" team of people to take care of the effort the new org makes and let them
+community core team to take care of the effort the new org makes and let them
 ran the day to day business so that the ESLint team rarely has to involve
 themselves.
 
@@ -177,9 +192,9 @@ Next to that, I think most important role would be to facilitate at least the
 contact with `@mysticatea`, so we can transfer his packages over to the
 `@eslint-community` org & gain `npm` publish rights for the packages.
 
-I can also see the ESLint team talk to the "core" team of the new org regarding
-creating new community maintained packages that are split out from the main
-ESLint repo. Examples of these kind of repos are:
+I can also see the ESLint team talk to the community core team of the new org
+regarding creating new community maintained packages that are split out from the
+main ESLint repo. Examples of these kind of repos are:
 
 - `eslint-plugin-node`  
   This plugin was recommended because of the deprecation of some rules in v7  
@@ -288,7 +303,8 @@ package), people could still use the old package without any extra problems
 -->
 
 - What exact acceptance criteria do we want to use?
-- What's the main place of communication for the "core" team?
+- What's the main place of communication for the community core team?
+- Would projects be allowed to accept sponsorships?
 - How does this relate to stuff in eg. `@standard`?  
   Would there be an expectency from the wider community or the
   `@eslint-community` org itself to transfer some stuff from these places?

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -41,17 +41,25 @@ back.
 ### How do you envision `@eslint-community`?
 
 Just like the [@jest-community](https://github.com/jest-community) org, the
-`@eslint-community` org would be a collection of widely depended upon ESLint
-related packages that aren't maintained anymore and are given back to the
-community.
+`@eslint-community` org would be a centralized home for ESLint related packages
+that don't belong in the main org or that are widely depended upon, aren't
+maintained anymore and are given back to the community.
 
 > Community repos for ESLint related projects
 
-The benefit of having the org in place would be that we _could_ create a
-structure to streamline the packages more. We _could_ for instance decide things
-like using the same tools, supporting the same Node/ESLint versions, if we want
-to release all "rescued" packages under the `@eslint-community` npm scope or
-not, ...
+The benefit of having the org in place would be that the community isn't
+dependent on one person's GitHub/npm account.  
+The added benefit is that we _could_ create a structure to streamline the
+packages more. We _could_ for instance decide things like using the same tools,
+supporting the same Node/ESLint versions, if we want to release all "rescued"
+packages under the `@eslint-community` npm scope or not, ...
+
+As a reference, `@jest-community` has the following goal & intention:
+
+> The goal of `@jest-community` is to have a loose but centralized home for
+> stuff `jest` core thinks is neat and worth having but doesn't belong in the
+> core itself. The org is a way to help ensure that these projects are not
+> dependent on one person's GitHub account in case they move on.
 
 ### Which projects should be involved?
 
@@ -157,14 +165,14 @@ main ESLint repo. Examples of these kind of repos are:
   <https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-node-rules>
 - `eslint-formatter-codeframe` & `eslint-formatter-table`  
   These were both in the main ESLint repo but were removed in v8 and are
-  currently maintained by [@fregante](https://github.com/fregante)
+  currently maintained by [@fregante](https://github.com/fregante)  
   <https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#-removed-codeframe-and-table-formatters>
 - `eslint-plugin-eslint-plugin`  
   This plugin is (together with `eslint-plugin-node`) a recommended plugin for
-  linting custom plugins.
+  linting custom plugins.  
   <https://eslint.org/docs/developer-guide/working-with-plugins#linting>
 - `eslint-utils` & `regexpp` These packages are both used by the main ESLint
-  repo & currently maintained by `@mysticatea`
+  repo & currently maintained by `@mysticatea`  
   <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/package.json#L66>
   <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/package.json#L87>
 

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -69,9 +69,16 @@ work to restore continuity of service - a process which would be invisible to
 users (i.e. users might see a pause in updates but not have to make changes -
 the updates would just resume).
 
+Packages that are living under the new community org would be allowed to (keep)
+accept(ing) sponsorship for the maintainers of that package.  
+If the community core team at some point decides to setup its own sponsorship
+collective (like the core ESLint org has its
+[Open Collective](https://opencollective.com/eslint)), packages could also
+include this collective & the community org in their `FUNDING.yml`.
+
 ### Which projects should be involved?
 
-I think all of [@aladdin-add](https://github.com/aladdin-add),
+All of [@aladdin-add](https://github.com/aladdin-add),
 [@ota-meshi](https://github.com/ota-meshi),
 [@voxpelli](https://github.com/voxpelli) & myself would be in for helping to
 maintain at least the following packages:
@@ -92,48 +99,70 @@ home) &
 —[@xjamundx](https://github.com/xjamundx)— that he would like to transfer it to
 the community org if one was going to exist).
 
+The goal of the new community org isn't to take over all widely depended upon
+ESLint related packages that are currently maintained by community memebers.  
+Packages like
+[`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)
+(which is currently maintained by
+[@sindresorhus](https://github.com/sindresorhus)) or packages from initiatives
+like [@typescript-eslint](https://github.com/typescript-eslint) or
+[@standard](https://github.com/standard) could perfectly stay at their current
+home.  
+If the maintainers of such packages would want to transfer these packages to the
+new community org, they could of course be accepted if they meet the acceptance
+criteria.
+
 ### What would be the acceptance criteria?
 
-I personally think that the acceptance criteria for a package to go under the
-`@eslint-community` org would be:
+The acceptance criteria for a package to go under the `@eslint-community` org
+would be:
 
 - Is it a package that is ESLint-related?  
-  Mostly this will be ESLint plugins, but I can see (unmaintained) dependencies
-  of such packages, closely related packages or packages split from the main
-  ESLint repo (like
+  Mostly this will be ESLint plugins, but (unmaintained) dependencies of such
+  packages, closely related packages or packages split from the main ESLint repo
+  (like
   [`eslint-formatter-codeframe`](https://github.com/fregante/eslint-formatter-codeframe)
   or
   [`eslint-formatter-table`](https://github.com/fregante/eslint-formatter-table),
   which are currently maintained by [@fregante](https://github.com/fregante)) or
   used by the main repo (like
   [`eslint-utils`](https://github.com/mysticatea/eslint-utils) &
-  [`regexpp`](https://github.com/mysticatea/regexpp)) to be in the
-  `@eslint-community` org as well.  
+  [`regexpp`](https://github.com/mysticatea/regexpp)) could go in the
+  `@eslint-community` org as well.
+
   It also shouldn't matter if the package is purely TypeScript-related or not,
   as refusing these packages and having a separate
   `@typescript-eslint-community` org would only fragmentize the ESLint community
   more without any real benefit.
 
+  Because plugins can expose their own (recommended) configs, the new org
+  already accepts config packages in some way.  
+  However, the community core team won't be eager to accept shared ESLint config
+  packages, as they can be very opinionated.  
+  Taking over these configs doesn't necessarily mean these are officially
+  endorsed by the ESLint TSC or the community core team, it just means that
+  maintenance is taken over and the community core team will ensure that the
+  wider community isn't held back by outdated packages.
+
 - Is it widely depended upon throughout the community?  
-  Don't have an exact number in mind, but all mentioned packages have at least
-  3M downloads/week.  
+  All mentioned packages have at least 3M downloads/week.  
   Only exceptions are `eslint-plugin-eslint-comments` (1M downloads/week) &
   `@mysticatea/eslint-plugin` (1.3K downloads/week), which is used as a
   devDependency for all other mentioned packages by `@mysticatea`.
 
-- It didn't receive an update in the last 12(?) months  
-  I think we can make an exception for packages that did get a PR merged which
-  was created by a member of the community core team (mostly for updating
+- It didn't receive an update in the last 6 months  
+  We can make an exception for packages that did get a PR merged which was
+  created by a member of the community core team (mostly for updating
   compatibility with newer versions of ESLint).
 
   We can also make an exception for packages that meet the other criteria, but
   where the owner want to transfer ownership to the new org.  
-  I can for instance imagine that people like [@gajus](https://github.com/gajus)
-  at some point would want to transfer ownership of plugins like
+  For instance people like [@gajus](https://github.com/gajus) at some point
+  could want to transfer ownership of plugins like
   [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype)
   and/or [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)
   if they would feel it would be better maintained by the community instead of
-  putting all workload on their shoulders. I can see the same happening for
+  putting all workload on their shoulders. The same could be happening for
   [`eslint-plugin-security`](https://github.com/nodesecurity/eslint-plugin-security),
   which is currently maintained by the
   [@nodesecurity](https://github.com/nodesecurity) team.
@@ -151,14 +180,18 @@ it up to date with the fork before continuing with other tasks.
 
 ### What permissions should maintainers have?
 
-I think it would be best to have some sort of a community core team (of at least
-3(?) people) that's making the decisions in terms of acceptance to the repo,
-which would (in addition to ESLint TSC) all be admins of the org.
+The ESLint TSC would assign a community core team (of at least 3 people) —that
+takes care of the effort the new org makes and let them run the day to day
+business—, which would (in addition to the ESLint TSC) all be admins of the new
+org.
 
-We can make a team (with sub-teams, if we want) for each package, where we give
-maintainer rights on the repo for that specific package, but keep admin rights
-to ESLint TSC & the community core team. This way we prevent that the repo would
-be destroyed from the org.
+Each package (and its directly related packages) will have its own team. If a
+certain team is responsible for several related packages, we could choose to add
+sub-teams if that makes sense.  
+All teams will be given maintainer rights on the repo for their specific
+package(s), but admin rights will be kept to the ESLint TSC & the community core
+team.  
+This way we prevent that a repo can be destroyed from the org.
 
 We'll create a setup where we publish new versions of the package with
 `eslintbot`. That way we can keep publishing new versions if someone would
@@ -171,10 +204,13 @@ The community core team would be responsible of administer the Code of Conduct
 of the organization.
 
 The community core team would also be responsible to contact package maintainers
-(outside of GitHub) if they appear inactive. If the package maintainers don't
-respond in a reasonable time frame (npm gives you 14(?) days to respond to a
-transfer request email), they could be considered non-responsive and the
-community core team can step in to appoint a new maintainer for the repository.
+(outside of GitHub) if they appear inactive.  
+Package maintainers will be seen as inactive if they didn't create a (necessary)
+release in the last 6 month _or_ if they haven't responded (properly) to any
+issue/PR/discussion in the last 3 months.  
+If the package maintainers don't respond in a reasonable time frame of 30 days,
+they will be considered non-responsive & the community core team can step in to
+appoint a new maintainer for the repository.
 
 **Bonus:** I think having our own place in the Discord server where we can
 discuss some things would be a good idea as well.  
@@ -184,20 +220,21 @@ ESLint target, how to handle disputes between maintainers, ...
 Having a channel for each separate package would maybe be a good idea as well,
 so the community has a chance to ask questions to the maintainers as well.
 
-### What should be the role of the ESLint team?
+### What should be the role of the ESLint TSC?
 
-The idea is that the ESLint team is the ultimate caretakers, they assign a
+The idea is that the ESLint TSC is the ultimate caretakers, they assign a
 community core team to take care of the effort the new org makes and let them
-ran the day to day business so that the ESLint team rarely has to involve
+ran the day to day business so that the ESLint TSC rarely has to involve
 themselves.
 
-Next to that, I think most important role would be to facilitate at least the
-contact with `@mysticatea`, so we can transfer his packages over to the
+Next to that, most important role would be to facilitate at least the contact
+with `@mysticatea`, so we can transfer his packages over to the
 `@eslint-community` org & gain `npm` publish rights for the packages.
 
-I can also see the ESLint team talk to the community core team of the new org
+The ESLint TSC could also talk to the community core team of the new org
 regarding creating new community maintained packages that are split out from the
-main ESLint repo. Examples of these kind of repos are:
+main ESLint repo or take over non-core plugins.  
+Examples of these kind of repos are:
 
 - `eslint-plugin-node`  
   This plugin was recommended because of the deprecation of some rules in v7  
@@ -210,10 +247,15 @@ main ESLint repo. Examples of these kind of repos are:
   This plugin is (together with `eslint-plugin-node`) a recommended plugin for
   linting custom plugins.  
   <https://eslint.org/docs/developer-guide/working-with-plugins#linting>
-- `eslint-utils` & `regexpp` These packages are both used by the main ESLint
-  repo & currently maintained by `@mysticatea`  
+- `eslint-utils` & `regexpp`  
+  These packages are both used by the main ESLint repo & currently maintained by
+  `@mysticatea`  
   <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/package.json#L66>
   <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/package.json#L87>
+- `eslint-plugin-markdown`  
+  This package is currently maintained by the ESLint TSC, but could perfectly
+  live in the new org  
+  <https://github.com/eslint/eslint-plugin-markdown>
 
 ## Documentation
 
@@ -256,8 +298,8 @@ be seen as the "correct" place for popular packages.
 
 It won't affect existing ESLint users, as package could be released under the
 same name on `npm`.  
-Even when we would release a package under the `@eslint-community` npm scope
-(for instance because we can't get the rights to publish to the existing npm
+Even when we would release a package under the `@eslint-community` `npm` scope
+(for instance because we can't get the rights to publish to the existing `npm`
 package), people could still use the old package without any extra problems
 (except for the ones they already had) if they wanted to.
 
@@ -288,8 +330,8 @@ package), people could still use the old package without any extra problems
   [@jsx-eslint](https://github.com/jsx-eslint) (which maintains
   [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y),
   [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react) &
-  [`jsx-ast-utils`](https://github.com/jsx-eslint/jsx-ast-utils)) &
-  [@standard](https://github.com/standard) (which maintains a couple of
+  [`jsx-ast-utils`](https://github.com/jsx-eslint/jsx-ast-utils)) & `@standard`
+  (which maintains a couple of
   [`standard`](https://github.com/standard/standard) related ESLint configs)
 
 ## Open Questions
@@ -307,22 +349,6 @@ package), people could still use the old package without any extra problems
 
 - What exact acceptance criteria do we want to use?
 - What's the main place of communication for the community core team?
-- Would projects be allowed to accept sponsorships?
-- How does this relate to stuff in eg. `@standard`?  
-  Would there be an expectancy from the wider community or the
-  `@eslint-community` org itself to transfer some stuff from these places?
-- What about projects like
-  [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)?  
-  Will it be considered a problem that such a plugin is under
-  [@sindresorhus](https://github.com/sindresorhus)' ownership rather than the
-  `@eslint-community` org?
-- How about something like
-  [`eslint-config-airbnb-base`](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base)?  
-  Could a ruleset like that be eligible for this new org if abandoned at some
-  point?  
-  Would there be a push by people to transfer such a module here?  
-  Will that make it look like an officially endorsed configuration?  
-  How would that affect organizations like `@standard`?
 
 ## Help Needed
 

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -1,31 +1,31 @@
 - Repo: No ESLint repos, only the ones mentioned below (owned by private
   persons)
 - Start Date: 2022-05-31
-- RFC PR:
+- RFC PR: <https://github.com/eslint/rfcs/pull/91>
 - Authors: [@aladdin-add](https://github.com/aladdin-add),
-  [@MichaelDeBoey](https://github.com/MichaelDeBoey),
-  [@ota-meshi](https://github.com/ota-meshi) &
-  [@voxpelli](https://github.com/voxpelli)
+  [@MichaelDeBoey](https://github.com/MichaelDeBoey) &
+  [@ota-meshi](https://github.com/ota-meshi)
 
-# `@eslint-community` GitHub organisation
+# `@eslint-community` GitHub organization
 
 ## Summary
 
 <!-- One-paragraph explanation of the feature. -->
 
-Facilitate a GitHub organisation
-([@eslint-community](https://github.com/eslint-community)) where community
-members could maintain widely used ESLint related packages that would otherwise
-get abandoned.
+Facilitate a GitHub organization (eg.
+[@eslint-community](https://github.com/eslint-community)) where community
+members can help ensure widely depended upon ESLint related packages stay up to
+date with newer ESLint releases and doesn't hold the wider community back.
 
 ## Motivation
 
 <!-- Why are we doing this? What use cases does it support? What is the expected
 outcome? -->
 
-There a some widely used ESLint related packages that aren't actively maintained
-anymore and we'd like to transfer them to a community owned GitHub organization
-(`@eslint-community`), so we can give them back to the community.
+There are some widely depended upon ESLint related packages that aren't kept up
+to date with eg. new ESLint releases. The community would like a place to
+collectively step in and ensure that these doesn't hold the wider community
+back.
 
 ## Detailed Design
 
@@ -41,30 +41,30 @@ anymore and we'd like to transfer them to a community owned GitHub organization
 ### How do you envision `@eslint-community`?
 
 Just like the [@jest-community](https://github.com/jest-community) org, the
-`@eslint-community` org would be a collection of important/widely used ESLint
-plugins/packages that aren't maintained anymore and are given back to the
+`@eslint-community` org would be a collection of widely depended upon ESLint
+related packages that aren't maintained anymore and are given back to the
 community.
 
 > Community repos for ESLint related projects
 
-The projects could be released under the `@eslint-community` scope in a later
-stage.
-
-The benefit of having the org in place would be that we could create a structure
-to streamline the packages more, i.e. tools used, supported Node/ESLint
-versions, ...
+The benefit of having the org in place would be that we _could_ create a
+structure to streamline the packages more. We _could_ for instance decide things
+like using the same tools, supporting the same Node/ESLint versions, if we want
+to release all "rescued" packages under the `@eslint-community` npm scope or
+not, ...
 
 ### Which projects should be involved?
 
 I think all of [@aladdin-add](https://github.com/aladdin-add),
-[@ota-meshi](https://github.com/ota-meshi) &
+[@ota-meshi](https://github.com/ota-meshi),
 [@voxpelli](https://github.com/voxpelli) & myself would be in for helping to
 maintain at least the following packages:
 [`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin),
 [`eslint-plugin-eslint-comments`](https://github.com/mysticatea/eslint-plugin-eslint-comments),
 [`eslint-plugin-es`](https://github.com/mysticatea/eslint-plugin-es),
 [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node),
-[`eslint-utils`](https://github.com/mysticatea/eslint-utils) (all from
+[`eslint-utils`](https://github.com/mysticatea/eslint-utils) &
+[`regexpp`](https://github.com/mysticatea/regexpp) (all from
 [@mysticatea](https://github.com/mysticatea)) &
 [`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise)
 (which is used a lot as well and was mentioned by the current maintainer
@@ -73,19 +73,23 @@ the community org if one was going to exist).
 
 ### What would be the acceptance criteria?
 
-I personally think that the acceptance criteria for a plugin to go under the
+I personally think that the acceptance criteria for a package to go under the
 `@eslint-community` org would be:
 
 - Is it a package that is ESLint-related?  
-  Mostly this will be ESLint configs/plugins, but I can see unmaintained
-  dependencies of such packages, closely related packages or packages split from
-  the main ESLint repo (like
+  Mostly this will be ESLint plugins, but I can see (unmaintained) dependencies
+  of such packages, closely related packages or packages split from the main
+  ESLint repo (like
   [`eslint-formatter-codeframe`](https://github.com/fregante/eslint-formatter-codeframe)
   or
   [`eslint-formatter-table`](https://github.com/fregante/eslint-formatter-table),
-  which are currently maintained by [@fregante](https://github.com/fregante)).
+  which are currently maintained by [@fregante](https://github.com/fregante)) or
+  used by the main repo (like
+  [`eslint-utils`](https://github.com/mysticatea/eslint-utils) &
+  [`regexpp`](https://github.com/mysticatea/regexpp)) to be in the
+  `@eslint-community` org as well.
 
-- Is it widely used throughout the community?  
+- Is it widely depended upon throughout the community?  
   Don't have an exact number in mind, but all mentioned packages have at least
   3M downloads/week.  
   Only exceptions are `eslint-plugin-eslint-comments` (1M downloads/week) &
@@ -118,10 +122,6 @@ owner of the repo to transfer ownership over to the new org, we could
 temporarily fork the repo & publish the package as
 `@eslint-community-fork/<package name>` or so.
 
-Maybe [@G-Rath](https://github.com/G-Rath) &
-[@SimenB](https://github.com/SimenB) could give some insights on the acceptance
-criteria for `@jest-community` & we can learn from their findings as well.
-
 ### What permissions should maintainers have?
 
 I think it would be best to have some sort of a "core" team (of at least 3(?)
@@ -153,16 +153,20 @@ regarding creating new community maintained packages that are split out from the
 main ESLint repo. Examples of these kind of repos are:
 
 - `eslint-plugin-node`  
-  This plugin was recommended because of the deprecation of some rules in v7  
+  This plugin was recommended because of the deprecation of some rules in v7
   <https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-node-rules>
 - `eslint-formatter-codeframe` & `eslint-formatter-table`  
   These were both in the main ESLint repo but were removed in v8 and are
-  currently maintained by [@fregante](https://github.com/fregante)  
+  currently maintained by [@fregante](https://github.com/fregante)
   <https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#-removed-codeframe-and-table-formatters>
 - `eslint-plugin-eslint-plugin`  
   This plugin is (together with `eslint-plugin-node`) a recommended plugin for
-  linting custom plugins.  
+  linting custom plugins.
   <https://eslint.org/docs/developer-guide/working-with-plugins#linting>
+- `eslint-utils` & `regexpp` These packages are both used by the main ESLint
+  repo & currently maintained by `@mysticatea`
+  <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/package.json#L66>
+  <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/package.json#L87>
 
 ## Documentation
 
@@ -171,7 +175,8 @@ main ESLint repo. Examples of these kind of repos are:
     on the ESLint blog to explain the motivation?
 -->
 
-I don't think this RFC needs a formal announcement on the ESLint blog.
+A formal announcement on the ESLint blog would be preferred to let the community
+know about this new org and about which forks we're maintaining.
 
 ## Drawbacks
 
@@ -186,9 +191,13 @@ I don't think this RFC needs a formal announcement on the ESLint blog.
     implementing this RFC as possible.
 -->
 
-I can't think of a reason why we would not want this.  
-Once we have access to the `@eslint-community` org & have the repos transfered,
-the "core" team can work out the rest of the process themselves.
+One of the drawbacks could be that this new `@eslint-community` org could give
+the impression that the packages owned by this new org are recommended by the
+core team.
+
+Secondly, It could also put pressure on packages from other ESLint related
+organizations/maintainers to transfer their project to this new org, as it could
+be seen as the "correct" place for popular packages.
 
 ## Backwards Compatibility Analysis
 
@@ -199,7 +208,11 @@ the "core" team can work out the rest of the process themselves.
 -->
 
 It won't affect existing ESLint users, as package could be released under the
-same name on `npm`.
+same name on `npm`.  
+Even when we would release a package under the `@eslint-community` npm scope
+(for instance because we can't get the rights to publish to the existing npm
+package), people could still use the old package without any extra problems
+(except for the ones they already had) if they wanted to.
 
 ## Alternatives
 
@@ -210,9 +223,27 @@ same name on `npm`.
     projects have already implemented a similar feature.
 -->
 
-Creating a fork of the above mentioned packages. This could however create
-ceveral forks (which would cause fragmentation in the community), but also has
-the burden of needing to update all existing dependants.
+- Private persons could create a fork of the above mentioned packages.  
+  This could however create ceveral well maintained forks, which would cause
+  fragmentation in the community.
+
+  More importantly, this could cause the "problem" of the fork being reliant on
+  that specific individual, which could put us in the same position
+  (abandoned/unmaintained package) all over again at some point in time.
+  Possibly having a new fork each X amount of time, would also have the burden
+  of needing to update all existing dependants each time.
+
+- The community could independently create multiple more focused organizations
+  to maintain a subset of ESLint related packages.  
+  Some examples of already existing organizations like that are
+  [@import-js](https://github.com/import-js) (which maintains
+  [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import)),
+  [@jsx-eslint](https://github.com/jsx-eslint) (which maintains
+  [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y),
+  [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react) &
+  [`jsx-ast-utils`](https://github.com/jsx-eslint/jsx-ast-utils)) &
+  [@standard](https://github.com/standard) (which maintains a couple of
+  [`standard`](https://github.com/standard/standard) related ESLint configs)
 
 ## Open Questions
 
@@ -229,6 +260,26 @@ the burden of needing to update all existing dependants.
 
 - What exact acceptance criteria do we want to use?
 - What's the main place of communication for the "core" team?
+- Will there be a single team collectively maintaining all modules within the
+  project? Or will each module possibly have their own maintainers?
+- What maintenance principles will be enforced?  
+  Will each module have their own standards, release flows, dependency update
+  checks etc or will it be streamlined across all modules?
+- How does this relate to stuff in eg. `@standard`?  
+  Would there be an expectency from the wider community or the
+  `@eslint-community` org itself to transfer some stuff from these places?
+- What about projects like
+  [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)?  
+  Will it be considered a problem that such a plugin is under
+  [@sindresorhus](https://github.com/sindresorhus)' ownership rather than the
+  `@eslint-community` org?
+- How about something like
+  [`eslint-config-airbnb-base`](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base)?  
+  Could a ruleset like that be eligible for this new org if abandoned at some
+  point?  
+  Would there be a push by people to transfer such a module here?  
+  Will that make it look like an officially endorsed configuration?  
+  How would that affect organizations like `@standard`?
 
 ## Help Needed
 
@@ -239,9 +290,9 @@ the burden of needing to update all existing dependants.
     of help would you need from the team?
 -->
 
-We would need to get access to the `@eslint-community` & be brought in contact
-with `@mysticatea` to transfer his repos to the new org & get `npm` publish
-rights.
+We would need to get access to the `@eslint-community` org & be brought in
+contact with `@mysticatea` to transfer his repos to the new org & get `npm`
+publish rights on these repos.
 
 ## Frequently Asked Questions
 
@@ -261,3 +312,9 @@ rights.
     If there is an issue, pull request, or other URL that provides useful
     context for this proposal, please include those links here.
 -->
+
+- https://github.com/eslint/eslint/issues/15383
+- https://github.com/eslint/eslint/discussions/15929
+- https://github.com/mysticatea/eslint-plugin/pull/29#issuecomment-1139495904
+- https://github.com/standard/eslint-config-standard/issues/192#issuecomment-1000279972
+- https://github.com/weiran-zsd/eslint-plugin-node/issues/8

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -71,10 +71,10 @@ the updates would just resume).
 
 Packages that are living under the new community org would be allowed to (keep)
 accept(ing) sponsorship for the maintainers of that package.  
-If the community core team at some point decides to setup its own sponsorship
-collective (like the core ESLint org has its
-[Open Collective](https://opencollective.com/eslint)), packages could also
-include this collective & the community org in their `FUNDING.yml`.
+The community core team will also setup its own sponsorship collective (like the
+core ESLint org has its [Open Collective](https://opencollective.com/eslint)),
+so packages should also include this collective & the community org in their
+`FUNDING.yml`.
 
 ### Which projects should be involved?
 
@@ -257,6 +257,10 @@ Examples of these kind of repos are:
   live in the new org  
   <https://github.com/eslint/eslint-plugin-markdown>
 
+As discussed in
+[the ESLint TSC Meeting of July 14th, 2022](https://github.com/eslint/tsc-meetings/blob/main/notes/2022/2022-07-14-transcript.md),
+the community core team will also be compensated out of the main ESLint budget.
+
 ## Documentation
 
 <!--
@@ -349,7 +353,6 @@ package), people could still use the old package without any extra problems
 
 - What exact acceptance criteria do we want to use?
 - What's the main place of communication for the community core team?
-- Will the community core team be compensated out of the main ESLint budget?
 
 ## Help Needed
 
@@ -363,16 +366,6 @@ package), people could still use the old package without any extra problems
 We would need to get access to the `@eslint-community` org & be brought in
 contact with `@mysticatea` to transfer his repos to the new org & get `npm`
 publish rights on these repos.
-
-## Frequently Asked Questions
-
-<!--
-    This section is optional but suggested.
-
-    Try to anticipate points of clarification that might be needed by
-    the people reviewing this RFC. Include those questions and answers
-    in this section.
--->
 
 ## Related Discussions
 

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -1,0 +1,263 @@
+- Repo: No ESLint repos, only the ones mentioned below (owned by private
+  persons)
+- Start Date: 2022-05-31
+- RFC PR:
+- Authors: [@aladdin-add](https://github.com/aladdin-add),
+  [@MichaelDeBoey](https://github.com/MichaelDeBoey),
+  [@ota-meshi](https://github.com/ota-meshi) &
+  [@voxpelli](https://github.com/voxpelli)
+
+# `@eslint-community` GitHub organisation
+
+## Summary
+
+<!-- One-paragraph explanation of the feature. -->
+
+Facilitate a GitHub organisation
+([@eslint-community](https://github.com/eslint-community)) where community
+members could maintain widely used ESLint related packages that would otherwise
+get abandoned.
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected
+outcome? -->
+
+There a some widely used ESLint related packages that aren't actively maintained
+anymore and we'd like to transfer them to a community owned GitHub organization
+(`@eslint-community`), so we can give them back to the community.
+
+## Detailed Design
+
+<!--
+   This is the bulk of the RFC.
+
+   Explain the design with enough detail that someone familiar with ESLint
+   can implement it by reading this document. Please get into specifics
+   of your approach, corner cases, and examples of how the change will be
+   used. Be sure to define any new terms in this section.
+-->
+
+### How do you envision `@eslint-community`?
+
+Just like the [@jest-community](https://github.com/jest-community) org, the
+`@eslint-community` org would be a collection of important/widely used ESLint
+plugins/packages that aren't maintained anymore and are given back to the
+community.
+
+> Community repos for ESLint related projects
+
+The projects could be released under the `@eslint-community` scope in a later
+stage.
+
+The benefit of having the org in place would be that we could create a structure
+to streamline the packages more, i.e. tools used, supported Node/ESLint
+versions, ...
+
+### Which projects should be involved?
+
+I think all of [@aladdin-add](https://github.com/aladdin-add),
+[@ota-meshi](https://github.com/ota-meshi) &
+[@voxpelli](https://github.com/voxpelli) & myself would be in for helping to
+maintain at least the following packages:
+[`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin),
+[`eslint-plugin-eslint-comments`](https://github.com/mysticatea/eslint-plugin-eslint-comments),
+[`eslint-plugin-es`](https://github.com/mysticatea/eslint-plugin-es),
+[`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node),
+[`eslint-utils`](https://github.com/mysticatea/eslint-utils) (all from
+[@mysticatea](https://github.com/mysticatea)) &
+[`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise)
+(which is used a lot as well and was mentioned by the current maintainer
+([@xjamundx](https://github.com/xjamundx)) that he would like to transfer it to
+the community org if one was going to exist).
+
+### What would be the acceptance criteria?
+
+I personally think that the acceptance criteria for a plugin to go under the
+`@eslint-community` org would be:
+
+- Is it a package that is ESLint-related?  
+  Mostly this will be ESLint configs/plugins, but I can see unmaintained
+  dependencies of such packages, closely related packages or packages split from
+  the main ESLint repo (like
+  [`eslint-formatter-codeframe`](https://github.com/fregante/eslint-formatter-codeframe)
+  or
+  [`eslint-formatter-table`](https://github.com/fregante/eslint-formatter-table),
+  which are currently maintained by [@fregante](https://github.com/fregante)).
+
+- Is it widely used throughout the community?  
+  Don't have an exact number in mind, but all mentioned packages have at least
+  3M downloads/week.  
+  Only exceptions are `eslint-plugin-eslint-comments` (1M downloads/week) &
+  `@mysticatea/eslint-plugin` (1.3K downloads/week), which is used as a
+  devDependency for all other mentioned packages by `@mysticatea`.
+
+- It didn't receive an update in the last 12(?) months  
+  I think we can make an exception for packages that did get a PR merged which
+  was created by a member of the new org's "core" team (mostly for updating
+  compatibility with newer versions of ESLint).
+
+  We can also make an exception for packages that meet the other criteria, but
+  where the owner want to transfer ownership to the new org.  
+  I can for instance imagine that
+  [@not-an-aardvark](https://github.com/not-an-aardvark) would want to transfer
+  ownership of
+  [`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin)
+  to the new org as well, as it's a recommended plugin for linting custom
+  plugins.  
+  <https://eslint.org/docs/developer-guide/working-with-plugins#linting>  
+  I can also imagine that people like [@gajus](https://github.com/gajus) at some
+  point wanting to transfer ownership of
+  [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype) or
+  [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc) if they
+  would feel it would be better maintained by the community instead of putting
+  all workload on their shoulders.
+
+If a package is meeting these criteria, but we can't get into contact with the
+owner of the repo to transfer ownership over to the new org, we could
+temporarily fork the repo & publish the package as
+`@eslint-community-fork/<package name>` or so.
+
+Maybe [@G-Rath](https://github.com/G-Rath) &
+[@SimenB](https://github.com/SimenB) could give some insights on the acceptance
+criteria for `@jest-community` & we can learn from their findings as well.
+
+### What permissions should maintainers have?
+
+I think it would be best to have some sort of a "core" team (of at least 3(?)
+people) that's making the decisions in terms of acceptance to the repo, which
+would all be admin of the org.
+
+We can make a team (with sub-teams if we want) for each package, where we give
+admin rights on the repo for that specific package.
+
+The core team would help maintain all repos, whereas people in specific teams
+would only help maintain these repositories.
+
+**Bonus:** I think having our own place in the Discord server where we can
+discuss some things would be a good idea as well.  
+This way the "core" team has an open place to discuss some common things like
+extracting common functionality into a separate package, minimum Node & ESLint
+target, how to handle disputes between maintainers, ...  
+Having a channel for each separate package would maybe be a good idea as well,
+so the community has a change to ask questions to the maintainers as well.
+
+### What should be the role of the ESLint team?
+
+I think most important role would be to facilitate at least the contact with
+`@mysticatea`, so we can transfer his packages over to the `@eslint-community`
+org & gain `npm` publish rights for the packages.
+
+Next to that, I can see the ESLint team talk to the "core" team of the new org
+regarding creating new community maintained packages that are split out from the
+main ESLint repo. Examples of these kind of repos are:
+
+- `eslint-plugin-node`  
+  This plugin was recommended because of the deprecation of some rules in v7  
+  <https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-node-rules>
+- `eslint-formatter-codeframe` & `eslint-formatter-table`  
+  These were both in the main ESLint repo but were removed in v8 and are
+  currently maintained by [@fregante](https://github.com/fregante)  
+  <https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#-removed-codeframe-and-table-formatters>
+- `eslint-plugin-eslint-plugin`  
+  This plugin is (together with `eslint-plugin-node`) a recommended plugin for
+  linting custom plugins.  
+  <https://eslint.org/docs/developer-guide/working-with-plugins#linting>
+
+## Documentation
+
+<!--
+    How will this RFC be documented? Does it need a formal announcement
+    on the ESLint blog to explain the motivation?
+-->
+
+I don't think this RFC needs a formal announcement on the ESLint blog.
+
+## Drawbacks
+
+<!--
+    Why should we *not* do this? Consider why adding this into ESLint
+    might not benefit the project or the community. Attempt to think
+    about any opposing viewpoints that reviewers might bring up.
+
+    Any change has potential downsides, including increased maintenance
+    burden, incompatibility with other tools, breaking existing user
+    experience, etc. Try to identify as many potential problems with
+    implementing this RFC as possible.
+-->
+
+I can't think of a reason why we would not want this.  
+Once we have access to the `@eslint-community` org & have the repos transfered,
+the "core" team can work out the rest of the process themselves.
+
+## Backwards Compatibility Analysis
+
+<!--
+    How does this change affect existing ESLint users? Will any behavior
+    change for them? If so, how are you going to minimize the disruption
+    to existing users?
+-->
+
+It won't affect existing ESLint users, as package could be released under the
+same name on `npm`.
+
+## Alternatives
+
+<!--
+    What other designs did you consider? Why did you decide against those?
+
+    This section should also include prior art, such as whether similar
+    projects have already implemented a similar feature.
+-->
+
+Creating a fork of the above mentioned packages. This could however create
+ceveral forks (which would cause fragmentation in the community), but also has
+the burden of needing to update all existing dependants.
+
+## Open Questions
+
+<!--
+    This section is optional, but is suggested for a first draft.
+
+    What parts of this proposal are you unclear about? What do you
+    need to know before you can finalize this RFC?
+
+    List the questions that you'd like reviewers to focus on. When
+    you've received the answers and updated the design to reflect them,
+    you can remove this section.
+-->
+
+- What exact acceptance criteria do we want to use?
+- What's the main place of communication for the "core" team?
+
+## Help Needed
+
+<!--
+    This section is optional.
+
+    Are you able to implement this RFC on your own? If not, what kind
+    of help would you need from the team?
+-->
+
+We would need to get access to the `@eslint-community` & be brought in contact
+with `@mysticatea` to transfer his repos to the new org & get `npm` publish
+rights.
+
+## Frequently Asked Questions
+
+<!--
+    This section is optional but suggested.
+
+    Try to anticipate points of clarification that might be needed by
+    the people reviewing this RFC. Include those questions and answers
+    in this section.
+-->
+
+## Related Discussions
+
+<!--
+    This section is optional but suggested.
+
+    If there is an issue, pull request, or other URL that provides useful
+    context for this proposal, please include those links here.
+-->

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -49,10 +49,11 @@ maintained anymore and are given back to the community.
 
 The benefit of having the org in place would be that the community isn't
 dependent on one person's GitHub/npm account.  
-The added benefit is that we _could_ create a structure to streamline the
-packages more. We _could_ for instance decide things like using the same tools,
-supporting the same Node/ESLint versions, if we want to release all "rescued"
-packages under the `@eslint-community` npm scope or not, ...
+The added benefit is that the people maintaining the packages in the new org
+_could_ create a structure to streamline the packages more. They _could_ for
+instance decide things like using the same tools, supporting the same
+Node/ESLint versions, if we want to release all "rescued" packages under the
+`@eslint-community` npm scope or not, ...
 
 As a reference, `@jest-community` has the following goal & intention:
 
@@ -60,6 +61,13 @@ As a reference, `@jest-community` has the following goal & intention:
 > stuff `jest` core thinks is neat and worth having but doesn't belong in the
 > core itself. The org is a way to help ensure that these projects are not
 > dependent on one person's GitHub account in case they move on.
+
+The beauty of having a shared org is that the release process is centralised, so
+no need to talk to npm about an ownership transfer and no need to fork and
+republish under a new name. Just appoint new maintainers on GitHub and they can
+work to restore continuity of service - a process which would be invisible to
+users (i.e. users might see a pause in updates but not have to make changes -
+the updates would just resume).
 
 ### Which projects should be involved?
 
@@ -73,10 +81,15 @@ maintain at least the following packages:
 [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node),
 [`eslint-utils`](https://github.com/mysticatea/eslint-utils) &
 [`regexpp`](https://github.com/mysticatea/regexpp) (all from
-[@mysticatea](https://github.com/mysticatea)) &
+[@mysticatea](https://github.com/mysticatea)),
+[`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin)
+(which is a recommended plugin for linting custom plugins & was already
+mentioned by [@not-an-aardvark](https://github.com/not-an-aardvark) —the current
+maintainer— to `@aladdin-add` that he wanted to transfer the repo to a better
+home) &
 [`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise)
 (which is used a lot as well and was mentioned by the current maintainer
-([@xjamundx](https://github.com/xjamundx)) that he would like to transfer it to
+—[@xjamundx](https://github.com/xjamundx)— that he would like to transfer it to
 the community org if one was going to exist).
 
 ### What would be the acceptance criteria?
@@ -95,7 +108,11 @@ I personally think that the acceptance criteria for a package to go under the
   used by the main repo (like
   [`eslint-utils`](https://github.com/mysticatea/eslint-utils) &
   [`regexpp`](https://github.com/mysticatea/regexpp)) to be in the
-  `@eslint-community` org as well.
+  `@eslint-community` org as well.  
+  It also shouldn't matter if the package is purely TypeScript-related or not,
+  as refusing these packages and having a separate
+  `@typescript-eslint-community` org would only fragmentize the ESLint community
+  more without any real benefit.
 
 - Is it widely depended upon throughout the community?  
   Don't have an exact number in mind, but all mentioned packages have at least
@@ -111,19 +128,12 @@ I personally think that the acceptance criteria for a package to go under the
 
   We can also make an exception for packages that meet the other criteria, but
   where the owner want to transfer ownership to the new org.  
-  I can for instance imagine that
-  [@not-an-aardvark](https://github.com/not-an-aardvark) would want to transfer
-  ownership of
-  [`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin)
-  to the new org as well, as it's a recommended plugin for linting custom
-  plugins.  
-  <https://eslint.org/docs/developer-guide/working-with-plugins#linting>  
-  I can also imagine that people like [@gajus](https://github.com/gajus) at some
-  point wanting to transfer ownership of
-  [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype) or
-  [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc) if they
-  would feel it would be better maintained by the community instead of putting
-  all workload on their shoulders.
+  I can for instance imagine that people like [@gajus](https://github.com/gajus)
+  at some point would want to transfer ownership of plugins like
+  [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype)
+  and/or [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)
+  if they would feel it would be better maintained by the community instead of
+  putting all workload on their shoulders.
 
 If a package is meeting these criteria, but we can't get into contact with the
 owner of the repo to transfer ownership over to the new org, we could
@@ -134,13 +144,19 @@ temporarily fork the repo & publish the package as
 
 I think it would be best to have some sort of a "core" team (of at least 3(?)
 people) that's making the decisions in terms of acceptance to the repo, which
-would all be admin of the org.
+would (in addition to ESLint TSC) all be admin of the org.
 
 We can make a team (with sub-teams if we want) for each package, where we give
 admin rights on the repo for that specific package.
 
-The core team would help maintain all repos, whereas people in specific teams
+The "core" team would help maintain all repos, whereas people in specific teams
 would only help maintain these repositories.
+
+The "core" team would also be responsible to contact package maintainers
+(outside of GitHub) if they appear inactive. If the package maintainers don't
+respond in a reasonable time frame (npm gives you 14(?) days to respond to a
+transfer request email), they could be considered non-responsive and the "core"
+team can step in to appoint a new maintainer for the repository.
 
 **Bonus:** I think having our own place in the Discord server where we can
 discuss some things would be a good idea as well.  
@@ -152,16 +168,21 @@ so the community has a change to ask questions to the maintainers as well.
 
 ### What should be the role of the ESLint team?
 
-I think most important role would be to facilitate at least the contact with
-`@mysticatea`, so we can transfer his packages over to the `@eslint-community`
-org & gain `npm` publish rights for the packages.
+The idea is that the ESLint team is the ultimate caretakers, they assign a
+"core" team of people to take care of the effort the new org makes and let them
+ran the day to day business so that the ESLint team rarely has to involve
+themselves.
 
-Next to that, I can see the ESLint team talk to the "core" team of the new org
-regarding creating new community maintained packages that are split out from the
-main ESLint repo. Examples of these kind of repos are:
+Next to that, I think most important role would be to facilitate at least the
+contact with `@mysticatea`, so we can transfer his packages over to the
+`@eslint-community` org & gain `npm` publish rights for the packages.
+
+I can also see the ESLint team talk to the "core" team of the new org regarding
+creating new community maintained packages that are split out from the main
+ESLint repo. Examples of these kind of repos are:
 
 - `eslint-plugin-node`  
-  This plugin was recommended because of the deprecation of some rules in v7
+  This plugin was recommended because of the deprecation of some rules in v7  
   <https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-node-rules>
 - `eslint-formatter-codeframe` & `eslint-formatter-table`  
   These were both in the main ESLint repo but were removed in v8 and are
@@ -268,11 +289,6 @@ package), people could still use the old package without any extra problems
 
 - What exact acceptance criteria do we want to use?
 - What's the main place of communication for the "core" team?
-- Will there be a single team collectively maintaining all modules within the
-  project? Or will each module possibly have their own maintainers?
-- What maintenance principles will be enforced?  
-  Will each module have their own standards, release flows, dependency update
-  checks etc or will it be streamlined across all modules?
 - How does this relate to stuff in eg. `@standard`?  
   Would there be an expectency from the wider community or the
   `@eslint-community` org itself to transfer some stuff from these places?

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -69,12 +69,11 @@ work to restore continuity of service - a process which would be invisible to
 users (i.e. users might see a pause in updates but not have to make changes -
 the updates would just resume).
 
-Packages that are living under the new community org would be allowed to (keep)
-accept(ing) sponsorship for the maintainers of that package.  
-The community core team will also setup its own sponsorship collective (like the
-core ESLint org has its [Open Collective](https://opencollective.com/eslint)),
-so packages should also include this collective & the community org in their
-`FUNDING.yml`.
+Although packages that are living under the new community org would be allowed
+to (keep) accept(ing) sponsorship for the maintainer(s) of that package, they
+should also include the
+[ESLint Open Collective](https://opencollective.com/eslint) & the
+[ESLint org](https://github.com/eslint) in their `FUNDING.yml`.
 
 ### Which projects should be involved?
 
@@ -100,7 +99,7 @@ home) &
 the community org if one was going to exist).
 
 The goal of the new community org isn't to take over all widely depended upon
-ESLint related packages that are currently maintained by community memebers.  
+ESLint related packages that are currently maintained by community members.  
 Packages like
 [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)
 (which is currently maintained by
@@ -108,9 +107,9 @@ Packages like
 like [@typescript-eslint](https://github.com/typescript-eslint) or
 [@standard](https://github.com/standard) could perfectly stay at their current
 home.  
-If the maintainers of such packages would want to transfer these packages to the
-new community org, they could of course be accepted if they meet the acceptance
-criteria.
+If the maintainer(s) of such packages would want to transfer these packages to
+the new community org, they could of course be accepted if they meet the
+acceptance criteria.
 
 ### What would be the acceptance criteria?
 
@@ -147,8 +146,8 @@ would be:
 - Is it widely depended upon throughout the community?  
   All mentioned packages have at least 3M downloads/week.  
   Only exceptions are `eslint-plugin-eslint-comments` (1M downloads/week) &
-  `@mysticatea/eslint-plugin` (1.3K downloads/week), which is used as a
-  devDependency for all other mentioned packages by `@mysticatea`.
+  `@mysticatea/eslint-plugin` (1.3K downloads/week), which is listed in
+  `devDependencies` of all other mentioned packages by `@mysticatea`.
 
 - It didn't receive an update in the last 6 months  
   We can make an exception for packages that did get a PR merged which was
@@ -156,9 +155,9 @@ would be:
   compatibility with newer versions of ESLint).
 
   We can also make an exception for packages that meet the other criteria, but
-  where the owner want to transfer ownership to the new org.  
-  For instance people like [@gajus](https://github.com/gajus) at some point
-  could want to transfer ownership of plugins like
+  where the owner wants to transfer ownership to the new org.  
+  For instance people like [@gajus](https://github.com/gajus) could at some
+  point want to transfer ownership of plugins like
   [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype)
   and/or [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)
   if they would feel it would be better maintained by the community instead of
@@ -175,8 +174,9 @@ If a package is meeting these criteria, but we can't get into contact with the
 owner of the repo to transfer ownership over to the new org, we could
 temporarily fork the repo into the new org. However, the ultimate goal would
 always be to transfer the original repo to the new org.  
-If we had a temporary fork, we should create PRs to the original repo to bring
-it up to date with the fork before continuing with other tasks.
+If we had a temporary fork and are able to transfer the original repo to the new
+org, we should first create PRs to the original repo to bring it up to date with
+the fork before continuing with other tasks.
 
 ### What permissions should maintainers have?
 
@@ -200,19 +200,19 @@ dissapear.
 The community core team would help maintain all repos, whereas people in
 specific teams would only help maintain these repositories.
 
-The community core team would be responsible of administer the Code of Conduct
-of the organization.
+The community core team would be responsible for administering the Code of
+Conduct of the organization.
 
-The community core team would also be responsible to contact package maintainers
-(outside of GitHub) if they appear inactive.  
+The community core team would also be responsible for contacting package
+maintainers (outside of GitHub) if they appear inactive.  
 Package maintainers will be seen as inactive if they didn't create a (necessary)
 release in the last 6 month _or_ if they haven't responded (properly) to any
 issue/PR/discussion in the last 3 months.  
 If the package maintainers don't respond in a reasonable time frame of 30 days,
-they will be considered non-responsive & the community core team can step in to
+they will be considered non-responsive & the community core team will step in to
 appoint a new maintainer for the repository.
 
-**Bonus:** I think having our own place in the Discord server where we can
+**Bonus:** Having our own place in the ESLint Discord server where we can
 discuss some things would be a good idea as well.  
 This way the community core team has an open place to discuss some common things
 like extracting common functionality into a separate package, minimum Node &
@@ -258,7 +258,7 @@ Examples of these kind of repos are:
   <https://github.com/eslint/eslint-plugin-markdown>
 
 As discussed in
-[the ESLint TSC Meeting of July 14th, 2022](https://github.com/eslint/tsc-meetings/blob/main/notes/2022/2022-07-14-transcript.md),
+[the ESLint TSC Meeting of July 14th, 2022](https://github.com/eslint/tsc-meetings/blob/main/notes/2022/2022-07-14.md#feat-create-eslint-community-github-organization-rfc),
 the community core team will also be compensated out of the main ESLint budget.
 
 ## Documentation
@@ -286,7 +286,7 @@ know about this new org and about which forks we're maintaining.
 
 One of the drawbacks could be that this new `@eslint-community` org could give
 the impression that the packages owned by this new org are recommended by the
-core team.
+ESLint TSC.
 
 Secondly, It could also put pressure on packages from other ESLint related
 organizations/maintainers to transfer their project to this new org, as it could

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -349,6 +349,7 @@ package), people could still use the old package without any extra problems
 
 - What exact acceptance criteria do we want to use?
 - What's the main place of communication for the community core team?
+- Will the community core team be compensated out of the main ESLint budget?
 
 ## Help Needed
 

--- a/designs/2022-community-eslint-org/README.md
+++ b/designs/2022-community-eslint-org/README.md
@@ -133,7 +133,10 @@ I personally think that the acceptance criteria for a package to go under the
   [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype)
   and/or [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)
   if they would feel it would be better maintained by the community instead of
-  putting all workload on their shoulders.
+  putting all workload on their shoulders. I can see the same happening for
+  [`eslint-plugin-security`](https://github.com/nodesecurity/eslint-plugin-security),
+  which is currently maintained by the
+  [@nodesecurity](https://github.com/nodesecurity) team.
 
 - It should agree to the code of conduct of the org
 - It should have an OSI-approved license
@@ -179,7 +182,7 @@ This way the community core team has an open place to discuss some common things
 like extracting common functionality into a separate package, minimum Node &
 ESLint target, how to handle disputes between maintainers, ...  
 Having a channel for each separate package would maybe be a good idea as well,
-so the community has a change to ask questions to the maintainers as well.
+so the community has a chance to ask questions to the maintainers as well.
 
 ### What should be the role of the ESLint team?
 
@@ -268,7 +271,7 @@ package), people could still use the old package without any extra problems
 -->
 
 - Private persons could create a fork of the above mentioned packages.  
-  This could however create ceveral well maintained forks, which would cause
+  This could however create several well maintained forks, which would cause
   fragmentation in the community.
 
   More importantly, this could cause the "problem" of the fork being reliant on
@@ -306,7 +309,7 @@ package), people could still use the old package without any extra problems
 - What's the main place of communication for the community core team?
 - Would projects be allowed to accept sponsorships?
 - How does this relate to stuff in eg. `@standard`?  
-  Would there be an expectency from the wider community or the
+  Would there be an expectancy from the wider community or the
   `@eslint-community` org itself to transfer some stuff from these places?
 - What about projects like
   [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)?  


### PR DESCRIPTION
## Summary

Facilitate a GitHub organization (eg. @eslint-community) where community members can help ensure widely depended upon ESLint related packages stay up to date with newer ESLint releases and doesn't hold the wider community back.

## Related Issues

This was originally put together in https://github.com/eslint/eslint/discussions/15929#discussioncomment-2850710

## Related discussions

- https://github.com/eslint/eslint/issues/15383
- https://github.com/eslint/eslint/discussions/15929
- https://github.com/mysticatea/eslint-plugin/pull/29#issuecomment-1139495904
- https://github.com/standard/eslint-config-standard/issues/192#issuecomment-1000279972
- https://github.com/weiran-zsd/eslint-plugin-node/issues/8

---

Rendered version: https://github.com/MichaelDeBoey/rfcs/blob/patch-1/designs/2022-community-eslint-org/README.md

