### PR TITLE
docs!: Docs information architecture refactor

### DIFF
--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -1,0 +1,235 @@
+- Repo:  eslint/eslint
+- Start Date: 2022-10-19
+- RFC PR: (leave this empty, to be filled in later)
+- Authors: Ben Perlmutter (@bpmutter)
+
+# Docs Information Architecture Update
+
+## Summary
+
+This document contains proposed changes to the information architecture in the ESLint documentation website, <https://eslint.org/docs>.
+
+On a high level, the proposed information architecture breaks the content into the following sections:
+
+- Use ESLint in Your Project: A refactor of the current [User Guide](https://eslint.org/docs/latest/user-guide/)
+- Extend ESLint: A refactor of the current [Developer Guide](https://eslint.org/docs/latest/developer-guide/), with some content moved to the section Maintain ESLint and Community Contributions
+- Maintain ESLint: Expansion of current [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide/), with some content taken from the current ‘Developer Guide’.
+- Community Contributions: Expansion of the current [Contributing section](https://eslint.org/docs/latest/developer-guide/contributing/) of the Developer Guide.
+
+## Motivation
+
+TODO: need to think on this one more than 'cuz nicholas said so'
+<!-- Why are we doing this? What use cases does it support? What is the expected
+outcome? -->
+
+## Detailed Design
+
+TODO: note abt how this isn't bulk of RFC. more like technical considerations
+<!--
+   This is the bulk of the RFC.
+
+   Explain the design with enough detail that someone familiar with ESLint
+   can implement it by reading this document. Please get into specifics
+   of your approach, corner cases, and examples of how the change will be
+   used. Be sure to define any new terms in this section.
+-->
+
+## Documentation
+
+The newly proposed information architecture should consist of the following sections and pages:
+
+<!--
+    How will this RFC be documented? Does it need a formal announcement
+    on the ESLint blog to explain the motivation?
+-->
+### [REFACTOR SECTION]  Use ESLint in Your Project
+
+- [RENAME SECTION] Use ESLint in Your Project
+  - Rename of current section User Guide
+- [NO-PAGE CHANGE] Getting Started
+  - Current page: [Getting Started](https://eslint.org/docs/latest/user-guide/getting-started)
+  - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: “Use ESLint in Your Project” documentation update** of the documentation update project.
+- [DO NOTHING TO SUBSECTION] Configuring
+  - Current page: [Configuring](https://eslint.org/docs/latest/user-guide/configuring/)
+  - Do not change the “Configuring” page and its children pages. Nicholas mentioned that there’s some major revamping to how configuration files work in ESLint, so let’s leave this subsection alone for now.
+- [RENAME PAGE] Command Line Interface Reference
+  - Current page: [Command Line Interface](https://eslint.org/docs/latest/user-guide/command-line-interface)
+- [RENAME PAGE] Rules Reference
+  - Current page: [Rules](https://eslint.org/docs/latest/rules/)
+- [RENAME PAGE] Formatters Reference
+  - Current page: [Formatters](https://eslint.org/docs/latest/user-guide/formatters/)
+- [NO CHANGE] Integrations
+  - Current page: [Integrations](https://eslint.org/docs/latest/user-guide/integrations)
+- [RENAME PAGE] Migrate to v8.x
+  - Current page: [Migrating to v8.0.0](https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0)
+
+### [REFACTOR SECTION]  Extend ESLint
+
+- [NEW PAGE] Overview
+  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 4: “Extend ESLint” documentation update** of the documentation update project.
+  - Contain overview type content explaining the various ways that you can extend ESLint:
+    - Create Plugins
+    - Create Custom Rules
+    - Create Custom Formatters
+    - Create Custom Parsers
+    - Shareable Configs
+  - Alternatively, repurpose the current section landing page[Developer Guide](https://eslint.org/docs/latest/developer-guide/) to be exposed in the side navigation and with the above content.
+- [RENAME & REFACTOR PAGE] Create Plugins
+  - Current page: [Working with Plugins](https://eslint.org/docs/latest/developer-guide/working-with-plugins)
+  - As noted below, convert the “Processors in Plugins” section into separate page “Custom Processors
+  - Add overview-style content at the top of the page explaining that this page explains how to bundle together the various parts of a plugin, and then publish it.
+- [RENAME PAGE] Custom Rules
+  - Current page: [Working with Rules](https://eslint.org/docs/latest/developer-guide/working-with-rules)
+- [RENAME PAGE] Custom Formatters
+  - Current page: [Working with Custom Formatters](https://eslint.org/docs/latest/developer-guide/working-with-custom-formatters)
+- [RENAME PAGE] Custom Parsers
+  - Current page: [Working with Custom Parsers](https://eslint.org/docs/latest/developer-guide/working-with-custom-parsers)
+  - Rename of “Working with Custom Parsers”
+- [NEW PAGE] Custom Processors
+  - Take most of content from the section [Processors in Plugins section on Work with Plugins Page](https://eslint.org/docs/latest/developer-guide/working-with-plugins#processors-in-plugins)
+- [RENAME PAGE] Share Configurations
+  - Current page: [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable-configs)
+- [NO CHANGE TO PAGE] Node.js API
+  - Current page: [Node.js API](https://eslint.org/docs/latest/developer-guide/nodejs-api)
+
+### [REFACTOR SECTION] Maintain ESLint
+
+- [NEW PAGE] Overview
+  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 5: “Maintain ESLint” documentation update** of the documentation update project.
+  - Alternatively, repurpose the current section landing page[Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide) to be exposed in the side navigation and with the above content.
+- [MOVE PAGE] Architecture
+  - Current page: [Architecture](https://eslint.org/docs/latest/developer-guide/architecture/)
+  - Note: in a previous conversation with Nicholas, he mentioned to me that this page is pretty out-of date.
+  - There should probably be a future unit of work to refactor this page.
+  - However, it’s not included in the information architecture updates.
+- [MOVE & REFACTOR PAGE] Set up Development Environment
+  - Consolidate the pages [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code) and [Set up a Development Environment](https://eslint.org/docs/latest/developer-guide/development-environment)
+  - Getting the source code is basically just a step in the process of setting up the development environment. Therefore, these two pages should be consolidated
+  - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
+- [NEW PAGE(S)] Any other technical pages for maintainers
+  - I don’t have any thoughts on what these should be right now. I would defer to the core maintainers on what they think other maintainers should know.
+  - I think that these additional technical pages would make sense to include in **Phase 5: “Maintain ESLint” documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).  
+  - NOTE: Maybe should be added, but not part of the initial IA project.
+- [MOVE PAGE] Run the Tests
+  - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
+- [NEW SECTION] Project Management
+  - [MOVE & RENAME PAGE] Manage Issues
+    - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
+  - [MOVE & RENAME PAGE] Review Pull Requests
+    - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
+  - [MOVE & RENAME PAGE] Manage Releases
+    - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
+  - [MOVE PAGE] Governance
+    - Current page: [Governance](https://eslint.org/docs/latest/maintainer-guide/governance)
+
+### [NEW SECTION] Community Contributions
+
+New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the “casual community contributor” is a fairly separate persona from the “extender” and “maintainer”, so it should be treated as such in the information architecture.
+
+- [MOVE & RENAME PAGE] section landing page
+  - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
+- [MOVE & RENAME PAGE] Report Bugs
+  - Current page: [Bug Reporting](https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs)
+- [MOVE & RENAME PAGE] Propose a New Rule
+  - Current page: [Proposing a New Rule](https://eslint.org/docs/latest/developer-guide/contributing/new-rules)
+- [MOVE & RENAME PAGE] Propose a Rule Change
+  - Current page: [Proposing a Rule Change](https://eslint.org/docs/latest/developer-guide/contributing/#:~:text=Proposing%20a-,Rule%20Change,-Want%20to%20make)
+- [MOVE & RENAME PAGE] Request a Change
+  - Current page: [Change Requests](https://eslint.org/docs/latest/developer-guide/contributing/changes)
+- [MOVE & RENAME PAGE] Work on Issues
+  - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
+- [NEW PAGE] Report Security Vulnerabilities
+  - Tales current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page for discoverability and SEO for an important subject.
+  - NOTE: Should be added, but not part of the initial IA project. Probably can be done as a one-off task or group in with one of the project phases.
+- [MOVE & RENAME PAGE] Submit a Pull Request
+  - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
+
+## Drawbacks
+
+TODO: breaking user experience
+<!--
+    Why should we *not* do this? Consider why adding this into ESLint
+    might not benefit the project or the community. Attempt to think 
+    about any opposing viewpoints that reviewers might bring up. 
+
+    Any change has potential downsides, including increased maintenance
+    burden, incompatibility with other tools, breaking existing user
+    experience, etc. Try to identify as many potential problems with
+    implementing this RFC as possible.
+-->
+
+## Backwards Compatibility Analysis
+
+HTTP redirects from existing content URL paths to the new content URL paths must be included as part of this project.
+
+<!--
+    How does this change affect existing ESLint users? Will any behavior
+    change for them? If so, how are you going to minimize the disruption
+    to existing users?
+-->
+
+## Alternatives
+
+<!--
+    What other designs did you consider? Why did you decide against those?
+
+    This section should also include prior art, such as whether similar
+    projects have already implemented a similar feature.
+-->
+
+## Open Questions
+
+1. Is it possible to have an always-opened folder named ‘Reference’ in which we put all these pages under? I.e similar to the “User Guide” folder, but as a subsection of the “User Guide” folder.
+2. TODO: more about if containers can not be pages as well.
+<!--
+    This section is optional, but is suggested for a first draft.
+
+    What parts of this proposal are you unclear about? What do you
+    need to know before you can finalize this RFC?
+
+    List the questions that you'd like reviewers to focus on. When
+    you've received the answers and updated the design to reflect them,
+    you can remove this section.
+-->
+
+## Help Needed
+
+I would likely need help with the following tasks:
+
+- Technical implementation details of how to handle redirects
+- Investigation of if there's a way to automate changing the internal link paths
+
+<!--
+    This section is optional.
+
+    Are you able to implement this RFC on your own? If not, what kind
+    of help would you need from the team?
+-->
+
+## Frequently Asked Questions
+
+### Why Rename Pages with Active Verb Phrases?
+
+This outline proposes renaming various titles to use active verb phrases instead of the current  gerund-based page name structure (ex. changing a page title from “Managing Issues” → “Manage Issues”). This is following a general technical writing best practice of avoiding gerunds in titles. For more information, refer to [this blog post about the subject](https://www.google.com/url?q=https://www.writethedocs.org/blog/newsletter-october-2022/%23gerunds-in-headings&sa=D&source=docs&ust=1665539063991039&usg=AOvVaw2HTT7RUQYPCcUenwVv0-Zt).
+
+### Will This Information Architecture Update Include Creating New Content?
+
+No. Additional content is to be created in Phases 3+ of the [documentation update project](https://github.com/eslint/eslint/issues/16365).
+
+<!--
+    This section is optional but suggested.
+
+    Try to anticipate points of clarification that might be needed by
+    the people reviewing this RFC. Include those questions and answers
+    in this section.
+-->
+
+## Related Discussions
+
+This work corresponds to **Phase 2: High-level information architecture update** of the [documentation update project](https://github.com/eslint/eslint/issues/16365).
+<!--
+    This section is optional but suggested.
+
+    If there is an issue, pull request, or other URL that provides useful
+    context for this proposal, please include those links here.
+-->

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -215,20 +215,20 @@ The proposed changes would include the following HTTP redirects from current con
 
 | Current URL | Proposed URL |
 | :---: | :---: |
-| <https://eslint.org/docs/latest/users/> | <https://eslint.org/docs/latest/users/> |
-| <https://eslint.org/docs/latest/users/core-concepts> | <https://eslint.org/docs/latest/users/core-concepts> |
-| <https://eslint.org/docs/latest/user-guide/configuring/> | <https://eslint.org/docs/latest/user/configuring/> |
-| <https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new> | <https://eslint.org/docs/latest/user/configure/configuration-files-new> |
-| <https://eslint.org/docs/latest/user-guide/configuring/configuration-files> | <https://eslint.org/docs/latest/users/configure/configuration-files> |
-| <https://eslint.org/docs/latest/user-guide/configuring/language-options> | <https://eslint.org/docs/latest/users/configure/language-options> |
-| <https://eslint.org/docs/latest/user-guide/configuring/rules> | <https://eslint.org/docs/latest/users/configure/rules> |
-| <https://eslint.org/docs/latest/user-guide/configuring/plugins> | <https://eslint.org/docs/latest/users/configure/plugins> |
-| <https://eslint.org/docs/latest/user-guide/configuring/ignoring-code> | <https://eslint.org/docs/latest/users/configure/ignore> |
-| <https://eslint.org/docs/latest/user-guide/command-line-interface> | <https://eslint.org/docs/latest/users/command-line-interface> |
-| <https://eslint.org/docs/latest/user-guide/formatters/> | <https://eslint.org/docs/latest/users/formatters/> |
-| <https://eslint.org/docs/latest/user-guide/integrations> | <https://eslint.org/docs/latest/users/integrations> |
-| <https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0> | <https://eslint.org/docs/latest/user/migrate-to-8.0.0> |
-| <https://eslint.org/docs/latest/user-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/users/> |
+| <https://eslint.org/docs/latest/user-guide/> | <https://eslint.org/docs/latest/use/core-concepts> |
+| <https://eslint.org/docs/latest/user-guide/core-concepts> | <https://eslint.org/docs/latest/use/core-concepts> |
+| <https://eslint.org/docs/latest/user-guide/configuring/> | <https://eslint.org/docs/latest/use/configure/> |
+| <https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new> | <https://eslint.org/docs/latest/use/configure/configuration-files-new> |
+| <https://eslint.org/docs/latest/user-guide/configuring/configuration-files> | <https://eslint.org/docs/latest/use/configure/configuration-files> |
+| <https://eslint.org/docs/latest/user-guide/configuring/language-options> | <https://eslint.org/docs/latest/use/configure/language-options> |
+| <https://eslint.org/docs/latest/user-guide/configuring/rules> | <https://eslint.org/docs/latest/use/configure/rules> |
+| <https://eslint.org/docs/latest/user-guide/configuring/plugins> | <https://eslint.org/docs/latest/use/configure/plugins> |
+| <https://eslint.org/docs/latest/user-guide/configuring/ignoring-code> | <https://eslint.org/docs/latest/use/configure/ignore> |
+| <https://eslint.org/docs/latest/user-guide/command-line-interface> | <https://eslint.org/docs/latest/use/command-line-interface> |
+| <https://eslint.org/docs/latest/user-guide/formatters/> | <https://eslint.org/docs/latest/use/formatters/> |
+| <https://eslint.org/docs/latest/user-guide/integrations> | <https://eslint.org/docs/latest/use/integrations> |
+| <https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0> | <https://eslint.org/docs/latest/use/migrate-to-8.0.0> |
+| <https://eslint.org/docs/latest/user-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/use/**> |
 | <https://eslint.org/docs/latest/developer-guide/architecture/> | <https://eslint.org/docs/latest/contribute/architecture/> |
 | <https://eslint.org/docs/latest/developer-guide/source-code> |  <https://eslint.org/docs/latest/contribute/development-environment> |
 | <https://eslint.org/docs/latest/developer-guide/development-environment> |  <https://eslint.org/docs/latest/contribute/development-environment> |

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -13,8 +13,8 @@ On a high level, the proposed IA breaks the content into the following sections:
 
 - Use ESLint in Your Project: A refactor of the current [User Guide](https://eslint.org/docs/latest/user-guide/)
 - Extend ESLint: A refactor of the current [Developer Guide](https://eslint.org/docs/latest/developer-guide/), with some content moved to the section Maintain ESLint and Community Contributions
-- Maintain ESLint: Expansion of current [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide/), with some content taken from the current ‘Developer Guide’.
-- Community Contributions: Expansion of the current [Contributing section](https://eslint.org/docs/latest/developer-guide/contributing/) of the Developer Guide.
+- Maintain ESLint: Expansion of current [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide/), with some content taken from the current Developer Guide.
+- Contribute to ESLint: Expansion of the current [Contributing section](https://eslint.org/docs/latest/developer-guide/contributing/) of the Developer Guide.
 
 ## Motivation
 
@@ -24,9 +24,9 @@ These personas are:
 
 - **The User**: Someone who wants to use ESLint as it currently exists, including plugins. The proposed 'Use ESLint in Your Project' section addresses this persona's needs.
 - **The Extender**: Someone who wants to extend the functionality of ESLint by creating a plugin, custom formatter, custom parser, sharable configuration, etc. The proposed 'Extend ESLint' section addresses this persona's needs.
-- **The Maintainer**: Someone who wants to contribute to the core ESLint project. The proposed 'Maintain ESLint' section addresses this persona's needs.
 - **The Community Contributor**: Someone who wants to make a small change to the core ESLint project, add a small change to the docs, or raise a Github issue. The proposed 'Community Contributions' section addresses this persona's needs.
   - Note: We haven't previously talked about this persona. However, after reading through   all the docs and considering the ESLint ecosystem, I think it makes sense to break this out as a separate persona.
+- **The Maintainer**: Someone who wants to maintain to the core ESLint project. The proposed 'Maintain ESLint' section addresses this persona's needs.
 
 While making broad IA changes to reorient the documentation around these personas, I also propose smaller, more cosmetic changes to the documentation website's IA to better align it with technical documentation best practices, like making page titles verb phrases and avoiding gerunds.
 
@@ -52,7 +52,7 @@ The newly proposed information architecture should consist of the following sect
   - Hidden in sidebar
 - [NO CHANGE] Getting Started
   - Current page: [Getting Started](https://eslint.org/docs/latest/user-guide/getting-started)
-  - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: “Use ESLint in Your Project” documentation update** of the documentation update project.
+  - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: "Use ESLint in Your Project" documentation update** of the documentation update project.
 - [NO CHANGE] Core Concepts
   - Current page: [Core Concepts](https://eslint.org/docs/latest/user-guide/core-concepts)
 - [RENAME PAGE] Configure
@@ -64,7 +64,7 @@ The newly proposed information architecture should consist of the following sect
     - [RENAME PAGE] Configuring Rules -> Configure Rules
     - [RENAME PAGE] Configuring Plugins -> Configure Plugins
     - [RENAME PAGE] Ignoring Code -> Ignore Code
-  - Do not change the “Configuring” page and its children pages. Nicholas mentioned that there’s some major revamping to how configuration files work in ESLint, so let’s leave this subsection alone for now.
+  - Do not change the "Configuring" page and its children pages. Nicholas mentioned that there’s some major revamping to how configuration files work in ESLint, so let’s leave this subsection alone for now.
 - [RENAME PAGE] Command Line Interface Reference
   - Current page: [Command Line Interface](https://eslint.org/docs/latest/user-guide/command-line-interface)
 - [RENAME PAGE] Rules Reference
@@ -88,10 +88,10 @@ The newly proposed information architecture should consist of the following sect
     - Create Custom Formatters
     - Create Custom Parsers
     - Shareable Configs
-  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 4: “Extend ESLint” documentation update** of the documentation update project.
+  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 4: "Extend ESLint" documentation update** of the documentation update project.
 - [RENAME & REFACTOR PAGE] Create Plugins
   - Current page: [Working with Plugins](https://eslint.org/docs/latest/developer-guide/working-with-plugins)
-  - As noted below, convert the “Processors in Plugins” section into separate page “Custom Processors
+  - As noted below, convert the "Processors in Plugins" section into separate page "Custom Processors
   - Add overview-style content at the top of the page explaining that this page explains how to bundle together the various parts of a plugin, and then publish it.
 - [RENAME PAGE] Custom Rules
   - Current page: [Working with Rules](https://eslint.org/docs/latest/developer-guide/working-with-rules)
@@ -100,7 +100,7 @@ The newly proposed information architecture should consist of the following sect
   - Current page: [Working with Custom Formatters](https://eslint.org/docs/latest/developer-guide/working-with-custom-formatters)
 - [RENAME PAGE] Custom Parsers
   - Current page: [Working with Custom Parsers](https://eslint.org/docs/latest/developer-guide/working-with-custom-parsers)
-  - Rename of “Working with Custom Parsers”
+  - Rename of "Working with Custom Parsers"
 - [NEW PAGE] Custom Processors
   - Take most of content from the section [Processors in Plugins section on Work with Plugins Page](https://eslint.org/docs/latest/developer-guide/working-with-plugins#processors-in-plugins)
 - [RENAME PAGE] Share Configurations
@@ -110,7 +110,7 @@ The newly proposed information architecture should consist of the following sect
 
 ### [NEW SECTION] Contribute to ESLint
 
-New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the “casual community contributor” is a fairly separate persona from the “extender” and “maintainer”, so it should be treated as such in the information architecture.
+New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the "casual community contributor" is a fairly separate persona from the "extender" and "maintainer", so it should be treated as such in the information architecture.
 
 - [MOVE & RENAME PAGE] Community Contributions section landing page
   - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
@@ -132,7 +132,7 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - However, it’s not included in the information architecture updates.
 - [MOVE & REFACTOR PAGE] Set up Development Environment
   - Consolidate the pages [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code) and [Set up a Development Environment](https://eslint.org/docs/latest/developer-guide/development-environment)
-  - Getting the source code is basically just a step in the process of setting up the development environment. Therefore, these two pages should be consolidated
+  - Getting the source code is basically just a step in the process of setting up the development environment. Therefore, these two pages should be consolidated.
   - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
 - [MOVE & RENAME PAGE] Work on Issues
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
@@ -159,8 +159,7 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
 - [NEW PAGE(S)] Any other technical pages for maintainers
   - I don’t have any thoughts on what these should be right now. I would defer to the core maintainers on what they think other maintainers should know.
-  - I think that these additional technical pages would make sense to include in **Phase 5: “Maintain ESLint” documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).
-  - NOTE: Maybe should be added, but not part of the initial IA project.
+  - I think that these additional technical pages would make sense to include in **Phase 5: "Maintain ESLint" documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).
 - [MOVE PAGE] Run the Tests
   - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
 
@@ -332,7 +331,7 @@ I would likely need help with the following tasks:
 
 ### Why Rename Pages with Active Verb Phrases?
 
-This outline proposes renaming various titles to use active verb phrases instead of the current gerund-based page name structure (ex. changing a page title from “Managing Issues” → “Manage Issues”). This is following a general technical writing best practice of avoiding gerunds in titles. For more information, refer to [this blog post about the subject](https://www.google.com/url?q=https://www.writethedocs.org/blog/newsletter-october-2022/%23gerunds-in-headings&sa=D&source=docs&ust=1665539063991039&usg=AOvVaw2HTT7RUQYPCcUenwVv0-Zt).
+This outline proposes renaming various titles to use active verb phrases instead of the current gerund-based page name structure (ex. changing a page title from "Managing Issues" → "Manage Issues"). This is following a general technical writing best practice of avoiding gerunds in titles. For more information, refer to [this blog post about the subject](https://www.google.com/url?q=https://www.writethedocs.org/blog/newsletter-october-2022/%23gerunds-in-headings&sa=D&source=docs&ust=1665539063991039&usg=AOvVaw2HTT7RUQYPCcUenwVv0-Zt).
 
 ### Will This Information Architecture Update Include Creating New Content?
 

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -232,16 +232,16 @@ The proposed changes would include the following HTTP redirects from current con
 | <https://eslint.org/docs/latest/developer-guide/source-code> |  <https://eslint.org/docs/latest/contribute/development-environment> |
 | <https://eslint.org/docs/latest/developer-guide/development-environment> |  <https://eslint.org/docs/latest/contribute/development-environment> |
 | <https://eslint.org/docs/latest/developer-guide/unit-tests> | <https://eslint.org/docs/latest/contribute/tests> |
-| <https://eslint.org/docs/latest/extend/working-with-rules> | <https://eslint.org/docs/latest/extend/custom-rules> |
+| <https://eslint.org/docs/latest/developer-guide/working-with-rules> | <https://eslint.org/docs/latest/extend/custom-rules> |
 | <https://eslint.org/docs/latest/developer-guide/working-with-plugins> | <https://eslint.org/docs/latest/extend/plugins> |
 | <https://eslint.org/docs/latest/developer-guide/working-with-custom-formatters> | <https://eslint.org/docs/latest/extend/custom-formatters> |
-| <https://eslint.org/docs/latest/developer-guide/working-with-custom-parsers> | <https://eslint.org/docs/latest/custom-parsers> |
-| <https://eslint.org/docs/latest/developer-guide/nodejs-api> | <https://eslint.org/docs/latest/extend/nodejs-api> |
+| <https://eslint.org/docs/latest/developer-guide/working-with-custom-parsers> | <https://eslint.org/docs/latest/extend/custom-parsers> |
+| <https://eslint.org/docs/latest/developer-guide/nodejs-api> | <https://eslint.org/docs/latest/integrate/nodejs-api> |
 | <https://eslint.org/docs/latest/developer-guide/contributing/> | <https://eslint.org/docs/latest/contribute/> |
 | <https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs> | <https://eslint.org/docs/latest/contribute/report-bugs> |
-| <https://eslint.org/docs/latest/developer-guide/contributing/new-rules> | <https://eslint.org/docs/latest/contribute/new-rule> |
-| <https://eslint.org/docs/latest/developer-guide/contributing/rule-changes> | <https://eslint.org/docs/latest/contribute/rule-change> |
-| <https://eslint.org/docs/latest/developer-guide/contributing/changes> | <https://eslint.org/docs/latest/contribute/change> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/new-rules> | <https://eslint.org/docs/latest/contribute/propose-new-rule> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/rule-changes> | <https://eslint.org/docs/latest/contribute/propose-rule-change> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/changes> | <https://eslint.org/docs/latest/contribute/request-change> |
 | <https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues> | <https://eslint.org/docs/latest/contribute/work-on-issue> |
 | <https://eslint.org/docs/latest/developer-guide/contributing/pull-requests> | <https://eslint.org/docs/latest/contribute/pull-requests> |
 | <https://eslint.org/docs/latest/developer-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/extend/**> |

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -214,7 +214,7 @@ The proposed changes would include the following HTTP redirects from current con
 
 | Current URL | Proposed URL |
 | :---: | :---: |
-| <https://eslint.org/docs/latest/user-guide/> | <https://eslint.org/docs/latest/use/core-concepts> |
+| <https://eslint.org/docs/latest/user-guide/> | <https://eslint.org/docs/latest/use/> |
 | <https://eslint.org/docs/latest/user-guide/core-concepts> | <https://eslint.org/docs/latest/use/core-concepts> |
 | <https://eslint.org/docs/latest/user-guide/configuring/> | <https://eslint.org/docs/latest/use/configure/> |
 | <https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new> | <https://eslint.org/docs/latest/use/configure/configuration-files-new> |

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -79,7 +79,7 @@ The newly proposed information architecture should consist of the following sect
 ### [REFACTOR SECTION]  Extend ESLint
 
 - [NO CHANGE] Extend ESLint landing page
-  - Current page:  [Developer Guide](https://eslint.org/docs/latest/developer-guide/)
+  - Take relevant content from page [Developer Guide](https://eslint.org/docs/latest/developer-guide/)
   - Hidden in sidebar
 - [NEW PAGE] Ways to Extend ESLint
   - Contain overview type content explaining the various ways that you can extend ESLint:
@@ -114,6 +114,7 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 
 - [MOVE & RENAME PAGE] Community Contributions section landing page
   - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
+  - Take relevant content from page [Developer Guide](https://eslint.org/docs/latest/developer-guide/)
   - Hidden in sidebar
 - [NEW PAGE] Code of Conduct
   - Takes current content from the [Read the Code of Conduct section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#read-the-code-of-conduct). Worth breaking out into its own page so content not only on the hidden landing page.
@@ -134,6 +135,8 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Consolidate the pages [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code) and [Set up a Development Environment](https://eslint.org/docs/latest/developer-guide/development-environment)
   - Getting the source code is basically just a step in the process of setting up the development environment. Therefore, these two pages should be consolidated.
   - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
+- [MOVE PAGE] Run the Tests
+  - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
 - [MOVE & RENAME PAGE] Work on Issues
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
 - [MOVE, EXPAND & RENAME PAGE] Submit a Pull Request
@@ -160,8 +163,6 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 - [NEW PAGE(S)] Any other technical pages for maintainers
   - I don’t have any thoughts on what these should be right now. I would defer to the core maintainers on what they think other maintainers should know.
   - I think that these additional technical pages would make sense to include in **Phase 5: "Maintain ESLint" documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).
-- [MOVE PAGE] Run the Tests
-  - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
 
 ### New Sidebar (summary)
 

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -122,6 +122,12 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Proposing a Rule Change](https://eslint.org/docs/latest/developer-guide/contributing/#:~:text=Proposing%20a-,Rule%20Change,-Want%20to%20make)
 - [MOVE & RENAME PAGE] Request a Change
   - Current page: [Change Requests](https://eslint.org/docs/latest/developer-guide/contributing/changes)
+- [MOVE & RENAME PAGE] Manage Issues
+  - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
+- [MOVE & RENAME PAGE] Review Pull Requests
+  - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
+- [MOVE & RENAME PAGE] Manage Releases
+  - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
 - [MOVE & RENAME PAGE] Work on Issues
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
 - [MOVE & RENAME PAGE] Submit a Pull Request
@@ -152,12 +158,6 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - NOTE: Maybe should be added, but not part of the initial IA project.
 - [MOVE PAGE] Run the Tests
   - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
-- [MOVE & RENAME PAGE] Manage Issues
-  - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
-- [MOVE & RENAME PAGE] Review Pull Requests
-  - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
-- [MOVE & RENAME PAGE] Manage Releases
-  - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
 
 ### New Sidebar (summary)
 
@@ -190,14 +190,14 @@ With the above changes, the left-hand side navigation will look like:
   - Propose a New Rule
   - Propose a Rule Change
   - Request a Change
+  - Architecture
+  - Set up a Development Environment
+  - Run the Tests
   - Work on Issues
   - Submit a Pull Request
   - Report Security Vulnerabilities
   - Governance
 - Maintain ESLint (landing page)
-  - Architecture
-  - Set up a Development Environment
-  - Run the Tests
   - Manage Issues
   - Review Pull Requests
   - Manage Releases
@@ -222,10 +222,10 @@ The proposed changes would include the following HTTP redirects from current con
 | <https://eslint.org/docs/latest/user-guide/integrations> | <https://eslint.org/docs/latest/users/integrations> |
 | <https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0> | <https://eslint.org/docs/latest/user/migrate-to-8.0.0> |
 | <https://eslint.org/docs/latest/user-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/users/> |
-| <https://eslint.org/docs/latest/developer-guide/architecture/> | <https://eslint.org/docs/latest/maintain/architecture/> |
-| <https://eslint.org/docs/latest/developer-guide/source-code> |  <https://eslint.org/docs/latest/maintain/development-environment> |
-| <https://eslint.org/docs/latest/developer-guide/development-environment> |  <https://eslint.org/docs/latest/maintain/development-environment> |
-| <https://eslint.org/docs/latest/developer-guide/unit-tests> | <https://eslint.org/docs/latest/maintain/tests> |
+| <https://eslint.org/docs/latest/developer-guide/architecture/> | <https://eslint.org/docs/latest/contribute/architecture/> |
+| <https://eslint.org/docs/latest/developer-guide/source-code> |  <https://eslint.org/docs/latest/contribute/development-environment> |
+| <https://eslint.org/docs/latest/developer-guide/development-environment> |  <https://eslint.org/docs/latest/contribute/development-environment> |
+| <https://eslint.org/docs/latest/developer-guide/unit-tests> | <https://eslint.org/docs/latest/contribute/tests> |
 | <https://eslint.org/docs/latest/extend/working-with-rules> | <https://eslint.org/docs/latest/extend/custom-rules> |
 | <https://eslint.org/docs/latest/developer-guide/working-with-plugins> | <https://eslint.org/docs/latest/extend/plugins> |
 | <https://eslint.org/docs/latest/developer-guide/working-with-custom-formatters> | <https://eslint.org/docs/latest/extend/custom-formatters> |

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -115,6 +115,8 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 - [MOVE & RENAME PAGE] Community Contributions section landing page
   - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
   - Hidden in sidebar
+- [NEW PAGE] Code of Conduct
+  - Takes current content from the [Read the Code of Conduct section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#read-the-code-of-conduct). Worth breaking out into its own page so content not only on the hidden landing page.
 - [MOVE & RENAME PAGE] Report Bugs
   - Current page: [Bug Reporting](https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs)
 - [MOVE & RENAME PAGE] Propose a New Rule
@@ -138,8 +140,6 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
   - Add the content from [Signing the CLA section](https://eslint.org/docs/latest/developer-guide/contributing/#signing-the-cla) from the Contributing overview page.
   Expand the content in [Step 7: send the pull request](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests#step-7-send-the-pull-request) with this content.
-- [NEW PAGE] Code of Conduct
-  - Takes current content from the [Read the Code of Conduct section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#read-the-code-of-conduct). Worth breaking out into its own page so content not only on the hidden landing page.
 - [NEW PAGE] Report Security Vulnerabilities
   - Takes current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page so that content not only on the hidden landing page and for discoverability and SEO for an important subject.
   - NOTE: Should be added, but not part of the initial IA project. Probably can be done as a one-off task or group in with one of the project phases.
@@ -192,6 +192,7 @@ With the above changes, the left-hand side navigation will look like:
   - Share Configurations
   - Node.js API Reference
 - Contribute to ESLint (landing page)
+  - Code of Conduct
   - Report Bugs
   - Propose a New Rule
   - Propose a Rule Change
@@ -201,7 +202,6 @@ With the above changes, the left-hand side navigation will look like:
   - Run the Tests
   - Work on Issues
   - Submit a Pull Request
-  - Code of Conduct
   - Report Security Vulnerabilities
   - Governance
 - Maintain ESLint (landing page)

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -63,7 +63,7 @@ The newly proposed information architecture should consist of the following sect
     - [RENAME PAGE] Configuring Language Options -> Configure Language Options
     - [RENAME PAGE] Configuring Rules -> Configure Rules
     - [RENAME PAGE] Configuring Plugins -> Configure Plugins
-    - [RENAME PAGE] Ignoring Rules -> Ignore Rules
+    - [RENAME PAGE] Ignoring Code -> Ignore Code
   - Do not change the “Configuring” page and its children pages. Nicholas mentioned that there’s some major revamping to how configuration files work in ESLint, so let’s leave this subsection alone for now.
 - [RENAME PAGE] Command Line Interface Reference
   - Current page: [Command Line Interface](https://eslint.org/docs/latest/user-guide/command-line-interface)
@@ -137,7 +137,7 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 - [MOVE, EXPAND & RENAME PAGE] Submit a Pull Request
   - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
   - Add the content from [Signing the CLA section](https://eslint.org/docs/latest/developer-guide/contributing/#signing-the-cla) from the Contributing overview page.
-  Expand the content in [Step 7: send the pull request](https://eslint.org/docs/latest/developer-guide/contributing/#signing-the-cla) with this content.
+  Expand the content in [Step 7: send the pull request](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests#step-7-send-the-pull-request) with this content.
 - [NEW PAGE] Code of Conduct
   - Takes current content from the [Read the Code of Conduct section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#read-the-code-of-conduct). Worth breaking out into its own page so content not only on the hidden landing page.
 - [NEW PAGE] Report Security Vulnerabilities
@@ -180,6 +180,7 @@ With the above changes, the left-hand side navigation will look like:
     - Ignore Code
   - Command Line Interface Reference
   - Rules Reference
+  - Formatters Reference
   - Integrations
   - Migrate to v8.x
 - Extend ESLint (landing page)

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -12,7 +12,7 @@ This document contains proposed changes to the information architecture (IA) in 
 On a high level, the proposed IA breaks the content into the following sections:
 
 - Use ESLint in Your Project: A refactor of the current [User Guide](https://eslint.org/docs/latest/user-guide/)
-- Extend ESLint: A refactor of the current [Developer Guide](https://eslint.org/docs/latest/developer-guide/), with some content moved to the section Maintain ESLint and Community Contributions
+- Extend ESLint: A refactor of the current [Developer Guide](https://eslint.org/docs/latest/developer-guide/), with some content moved to the sections Maintain ESLint and Contribute to ESLint
 - Maintain ESLint: Expansion of current [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide/), with some content taken from the current Developer Guide.
 - Contribute to ESLint: Expansion of the current [Contributing section](https://eslint.org/docs/latest/developer-guide/contributing/) of the Developer Guide.
 
@@ -24,8 +24,7 @@ These personas are:
 
 - **The User**: Someone who wants to use ESLint as it currently exists, including plugins. The proposed 'Use ESLint in Your Project' section addresses this persona's needs.
 - **The Extender**: Someone who wants to extend the functionality of ESLint by creating a plugin, custom formatter, custom parser, sharable configuration, etc. The proposed 'Extend ESLint' section addresses this persona's needs.
-- **The Community Contributor**: Someone who wants to make a small change to the core ESLint project, add a small change to the docs, or raise a Github issue. The proposed 'Community Contributions' section addresses this persona's needs.
-  - Note: We haven't previously talked about this persona. However, after reading through   all the docs and considering the ESLint ecosystem, I think it makes sense to break this out as a separate persona.
+- **The Community Contributor**: Someone who wants to make a small change to the core ESLint project, add a small change to the docs, or raise a Github issue. The proposed 'Contribute to ESLint' section addresses this persona's needs.
 - **The Maintainer**: Someone who wants to maintain to the core ESLint project. The proposed 'Maintain ESLint' section addresses this persona's needs.
 
 While making broad IA changes to reorient the documentation around these personas, I also propose smaller, more cosmetic changes to the documentation website's IA to better align it with technical documentation best practices, like making page titles verb phrases and avoiding gerunds.
@@ -112,7 +111,7 @@ The newly proposed information architecture should consist of the following sect
 
 New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the "casual community contributor" is a fairly separate persona from the "extender" and "maintainer", so it should be treated as such in the information architecture.
 
-- [MOVE & RENAME PAGE] Community Contributions section landing page
+- [MOVE & RENAME PAGE] Contribute to ESLint section landing page
   - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
   - Take relevant content from page [Developer Guide](https://eslint.org/docs/latest/developer-guide/)
   - Hidden in sidebar

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -22,15 +22,15 @@ The motivation of this proposed change to the ESLint documentation IA is to reor
 
 These personas are:
 
-- **The User**: Someone who wants to use ESLint as it currently exists, including plugins.
-- **The Extender**: Someone who wants to extend the functionality of ESLint by creating a plugin, custom formatter, custom parser, sharable configuration, etc.
-- **The Maintainer**: Someone who wants to contribute to the core ESLint project.
-- **The Community Contributor**: Someone who wants to make a small change to the core ESLint project, add a small change to the docs, or raise a Github issue.
+- **The User**: Someone who wants to use ESLint as it currently exists, including plugins. The proposed 'Use ESLint in Your Project' section addresses this persona's needs.
+- **The Extender**: Someone who wants to extend the functionality of ESLint by creating a plugin, custom formatter, custom parser, sharable configuration, etc. The proposed 'Extend ESLint' section addresses this persona's needs.
+- **The Maintainer**: Someone who wants to contribute to the core ESLint project. The proposed 'Maintain ESLint' section addresses this persona's needs.
+- **The Community Contributor**: Someone who wants to make a small change to the core ESLint project, add a small change to the docs, or raise a Github issue. The proposed 'Community Contributions' section addresses this persona's needs.
   - Note: We haven't previously talked about this persona. However, after reading through   all the docs and considering the ESLint ecosystem, I think it makes sense to break this out as a separate persona.
 
-While making broad IA changes to reorient the documentation around these personas, I also propose smaller, more cosmetic changes to the documentation website's information architecture to better align it with technical documentation best practices, like making page titles verb phrases and avoiding gerunds.
+While making broad IA changes to reorient the documentation around these personas, I also propose smaller, more cosmetic changes to the documentation website's IA to better align it with technical documentation best practices, like making page titles verb phrases and avoiding gerunds.
 
-As a result of these changes, the ESLint documentation all personas will be able to better navigate the documentation and better complete the tasks that they're using ESLint for.
+As a result of these changes, all personas will be able to better navigate the ESLint documentation and better complete the tasks that they're using ESLint for.
 
 <!-- Why are we doing this? What use cases does it support? What is the expected
 outcome? -->
@@ -47,9 +47,14 @@ The newly proposed information architecture should consist of the following sect
 
 - [RENAME SECTION] Use ESLint in Your Project
   - Rename of current section User Guide
-- [NO-PAGE CHANGE] Getting Started
+- [EXPOSE IN IA] Use ESLint in Your Project landing page
+  - Current page: [User Guide landing page](https://eslint.org/docs/latest/user-guide/)
+  - Make accessible by clicking "Use ESLint in Your Project" in the side table of contents. Currently can only navigate to this page by accessing the URL.
+- [NO CHANGE] Getting Started
   - Current page: [Getting Started](https://eslint.org/docs/latest/user-guide/getting-started)
   - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: “Use ESLint in Your Project” documentation update** of the documentation update project.
+- [NO CHANGE] Core Concepts
+  - Current page: [Core Concepts](https://eslint.org/docs/latest/user-guide/core-concepts)
 - [DO NOTHING TO SUBSECTION] Configuring
   - Current page: [Configuring](https://eslint.org/docs/latest/user-guide/configuring/)
   - Do not change the “Configuring” page and its children pages. Nicholas mentioned that there’s some major revamping to how configuration files work in ESLint, so let’s leave this subsection alone for now.
@@ -66,15 +71,15 @@ The newly proposed information architecture should consist of the following sect
 
 ### [REFACTOR SECTION]  Extend ESLint
 
-- [NEW PAGE] Overview
-  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 4: “Extend ESLint” documentation update** of the documentation update project.
+- [EXPOSE IN IA] Extend ESLint landing page
+  - Repurpose the current section landing page [Developer Guide](https://eslint.org/docs/latest/developer-guide/) to be exposed in the side navigation and with the below content.
   - Contain overview type content explaining the various ways that you can extend ESLint:
     - Create Plugins
     - Create Custom Rules
     - Create Custom Formatters
     - Create Custom Parsers
     - Shareable Configs
-  - Alternatively, repurpose the current section landing page[Developer Guide](https://eslint.org/docs/latest/developer-guide/) to be exposed in the side navigation and with the above content.
+  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 4: “Extend ESLint” documentation update** of the documentation update project.
 - [RENAME & REFACTOR PAGE] Create Plugins
   - Current page: [Working with Plugins](https://eslint.org/docs/latest/developer-guide/working-with-plugins)
   - As noted below, convert the “Processors in Plugins” section into separate page “Custom Processors
@@ -95,9 +100,9 @@ The newly proposed information architecture should consist of the following sect
 
 ### [REFACTOR SECTION] Maintain ESLint
 
-- [NEW PAGE] Overview
+- [EXPOSE IN IA] Maintain ESLint section landing page
+  - Repurpose the current section landing page [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide) to be exposed in the side navigation and with the above content.
   - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 5: “Maintain ESLint” documentation update** of the documentation update project.
-  - Alternatively, repurpose the current section landing page[Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide) to be exposed in the side navigation and with the above content.
 - [MOVE PAGE] Architecture
   - Current page: [Architecture](https://eslint.org/docs/latest/developer-guide/architecture/)
   - Note: in a previous conversation with Nicholas, he mentioned to me that this page is pretty out-of date.
@@ -127,7 +132,7 @@ The newly proposed information architecture should consist of the following sect
 
 New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the “casual community contributor” is a fairly separate persona from the “extender” and “maintainer”, so it should be treated as such in the information architecture.
 
-- [MOVE & RENAME PAGE] section landing page
+- [MOVE & RENAME PAGE] Community Contributions section landing page
   - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
 - [MOVE & RENAME PAGE] Report Bugs
   - Current page: [Bug Reporting](https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs)
@@ -176,7 +181,7 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 
 ## Alternatives
 
-- Do not change the information architecture, but only
+- Do not change the IA. Only update documentation within the existing IA as part of the [documentation update project](https://github.com/eslint/eslint/issues/16365).
 
 <!--
     What other designs did you consider? Why did you decide against those?
@@ -187,9 +192,9 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 
 ## Open Questions
 
-1. Is it possible to have an always-opened folder named ‘Reference’ in which we put all these pages under? I.e similar to the “User Guide” folder, but as a subsection of the “User Guide” folder.
-2. Is there a way to automatically change all the internal links that'll be broken by these updates?
-3. Can you create a side navigation folder that is not also a page?
+1. Is there a way to automatically change all the internal links that'll be broken by these updates?
+1. Can you create a side navigation folder that is not also a page?
+1. How to make section landing pages navigable from the side table of contents? (For example, the proposed page "Use ESLint in Your Project landing page")
 
 <!--
     This section is optional, but is suggested for a first draft.
@@ -208,7 +213,7 @@ I would likely need help with the following tasks:
 
 - Technical implementation details of how to handle redirects
 - I may need some help with updating the side navigation.
-- Investigation of if there's a way to automate changing the internal link paths
+- Investigate if there's a way to automate changing the internal link paths.
 
 <!--
     This section is optional.

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -124,11 +124,11 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Change Requests](https://eslint.org/docs/latest/developer-guide/contributing/changes)
 - [MOVE & RENAME PAGE] Work on Issues
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
+- [MOVE & RENAME PAGE] Submit a Pull Request
+  - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
 - [NEW PAGE] Report Security Vulnerabilities
   - Tales current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page for discoverability and SEO for an important subject.
   - NOTE: Should be added, but not part of the initial IA project. Probably can be done as a one-off task or group in with one of the project phases.
-- [MOVE & RENAME PAGE] Submit a Pull Request
-  - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
 - [MOVE PAGE] Governance
   - Current page: [Governance](https://eslint.org/docs/latest/maintainer-guide/governance)
 
@@ -191,8 +191,8 @@ With the above changes, the left-hand side navigation will look like:
   - Propose a Rule Change
   - Request a Change
   - Work on Issues
-  - Report Security Vulnerabilities
   - Submit a Pull Request
+  - Report Security Vulnerabilities
   - Governance
 - Maintain ESLint (landing page)
   - Architecture

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -134,8 +134,10 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
 - [MOVE & RENAME PAGE] Work on Issues
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
-- [MOVE & RENAME PAGE] Submit a Pull Request
+- [MOVE, EXPAND & RENAME PAGE] Submit a Pull Request
   - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
+  - Add the content from [Signing the CLA section](https://eslint.org/docs/latest/developer-guide/contributing/#signing-the-cla) from the Contributing overview page.
+  Expand the content in [Step 7: send the pull request](https://eslint.org/docs/latest/developer-guide/contributing/#signing-the-cla) with this content.
 - [NEW PAGE] Code of Conduct
   - Takes current content from the [Read the Code of Conduct section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#read-the-code-of-conduct). Worth breaking out into its own page so content not only on the hidden landing page.
 - [NEW PAGE] Report Security Vulnerabilities

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -55,8 +55,15 @@ The newly proposed information architecture should consist of the following sect
   - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: “Use ESLint in Your Project” documentation update** of the documentation update project.
 - [NO CHANGE] Core Concepts
   - Current page: [Core Concepts](https://eslint.org/docs/latest/user-guide/core-concepts)
-- [DO NOTHING TO SUBSECTION] Configuring
+- [RENAME PAGE] Configure
   - Current page: [Configuring](https://eslint.org/docs/latest/user-guide/configuring/)
+  - [RENAME PAGES] Rename the child pages of Configuring as follows:
+    - [NO CHANGE] Configuration Files (New)
+    - [NO CHANGE] Configuration Files
+    - [RENAME PAGE] Configuring Language Options -> Configure Language Options
+    - [RENAME PAGE] Configuring Rules -> Configure Rules
+    - [RENAME PAGE] Configuring Plugins -> Configure Plugins
+    - [RENAME PAGE] Ignoring Rules -> Ignore Rules
   - Do not change the “Configuring” page and its children pages. Nicholas mentioned that there’s some major revamping to how configuration files work in ESLint, so let’s leave this subsection alone for now.
 - [RENAME PAGE] Command Line Interface Reference
   - Current page: [Command Line Interface](https://eslint.org/docs/latest/user-guide/command-line-interface)
@@ -95,8 +102,32 @@ The newly proposed information architecture should consist of the following sect
   - Take most of content from the section [Processors in Plugins section on Work with Plugins Page](https://eslint.org/docs/latest/developer-guide/working-with-plugins#processors-in-plugins)
 - [RENAME PAGE] Share Configurations
   - Current page: [Shareable Configs](https://eslint.org/docs/latest/developer-guide/shareable-configs)
-- [NO CHANGE TO PAGE] Node.js API
+- [NO CHANGE TO PAGE] Node.js API Reference
   - Current page: [Node.js API](https://eslint.org/docs/latest/developer-guide/nodejs-api)
+
+### [NEW SECTION] Contribute to ESLint
+
+New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the “casual community contributor” is a fairly separate persona from the “extender” and “maintainer”, so it should be treated as such in the information architecture.
+
+- [MOVE & RENAME PAGE] Community Contributions section landing page
+  - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
+- [MOVE & RENAME PAGE] Report Bugs
+  - Current page: [Bug Reporting](https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs)
+- [MOVE & RENAME PAGE] Propose a New Rule
+  - Current page: [Proposing a New Rule](https://eslint.org/docs/latest/developer-guide/contributing/new-rules)
+- [MOVE & RENAME PAGE] Propose a Rule Change
+  - Current page: [Proposing a Rule Change](https://eslint.org/docs/latest/developer-guide/contributing/#:~:text=Proposing%20a-,Rule%20Change,-Want%20to%20make)
+- [MOVE & RENAME PAGE] Request a Change
+  - Current page: [Change Requests](https://eslint.org/docs/latest/developer-guide/contributing/changes)
+- [MOVE & RENAME PAGE] Work on Issues
+  - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
+- [NEW PAGE] Report Security Vulnerabilities
+  - Tales current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page for discoverability and SEO for an important subject.
+  - NOTE: Should be added, but not part of the initial IA project. Probably can be done as a one-off task or group in with one of the project phases.
+- [MOVE & RENAME PAGE] Submit a Pull Request
+  - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
+- [MOVE PAGE] Governance
+  - Current page: [Governance](https://eslint.org/docs/latest/maintainer-guide/governance)
 
 ### [REFACTOR SECTION] Maintain ESLint
 
@@ -125,30 +156,94 @@ The newly proposed information architecture should consist of the following sect
     - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
   - [MOVE & RENAME PAGE] Manage Releases
     - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
-  - [MOVE PAGE] Governance
-    - Current page: [Governance](https://eslint.org/docs/latest/maintainer-guide/governance)
 
-### [NEW SECTION] Community Contributions
+### New Sidebar (summary)
 
-New top-level section of the docs based on the [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/) section. Breaking this out as a separate section because I think the “casual community contributor” is a fairly separate persona from the “extender” and “maintainer”, so it should be treated as such in the information architecture.
+With the above changes, the left-hand side navigation will look like:
 
-- [MOVE & RENAME PAGE] Community Contributions section landing page
-  - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
-- [MOVE & RENAME PAGE] Report Bugs
-  - Current page: [Bug Reporting](https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs)
-- [MOVE & RENAME PAGE] Propose a New Rule
-  - Current page: [Proposing a New Rule](https://eslint.org/docs/latest/developer-guide/contributing/new-rules)
-- [MOVE & RENAME PAGE] Propose a Rule Change
-  - Current page: [Proposing a Rule Change](https://eslint.org/docs/latest/developer-guide/contributing/#:~:text=Proposing%20a-,Rule%20Change,-Want%20to%20make)
-- [MOVE & RENAME PAGE] Request a Change
-  - Current page: [Change Requests](https://eslint.org/docs/latest/developer-guide/contributing/changes)
-- [MOVE & RENAME PAGE] Work on Issues
-  - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
-- [NEW PAGE] Report Security Vulnerabilities
-  - Tales current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page for discoverability and SEO for an important subject.
-  - NOTE: Should be added, but not part of the initial IA project. Probably can be done as a one-off task or group in with one of the project phases.
-- [MOVE & RENAME PAGE] Submit a Pull Request
-  - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
+- Use ESLint in Your Project (landing page)
+  - Getting Started
+  - Core Concepts
+  - Configure
+    - Configuration Files (New)
+    - Configuration Files
+    - Configure Language Options
+    - Configure Rules
+    - Configure Plugins
+    - Ignore Code
+  - Command Line Interface Reference
+  - Rules Reference
+  - Integrations
+  - Migrate to v8.x
+- Extend ESLint (landing page)
+  - Create Plugins
+  - Custom Rules
+  - Custom Formatters
+  - Custom Parsers
+  - Custom Processors
+  - Share Configurations
+  - Node.js API Reference
+- Contribute to ESLint (landing page)
+  - Report Bugs
+  - Propose a New Rule
+  - Propose a Rule Change
+  - Request a Change
+  - Work on Issues
+  - Report Security Vulnerabilities
+  - Submit a Pull Request
+  - Governance
+- Maintain ESLint (landing page)
+  - Architecture
+  - Set up a Development Environment
+  - Run the Tests
+  - Project Management
+    - Manage Issues
+    - Review Pull Requests
+    - Manage Releases
+
+### HTTP Redirects
+
+The proposed changes would include the following HTTP redirects from current content locations to the locations proposed in the above outline.
+
+| Current URL | Proposed URL |
+| :---: | :---: |
+| <https://eslint.org/docs/latest/users/> | <https://eslint.org/docs/latest/users/> |
+| <https://eslint.org/docs/latest/users/core-concepts> | <https://eslint.org/docs/latest/users/core-concepts> |
+| <https://eslint.org/docs/latest/user-guide/configuring/> | <https://eslint.org/docs/latest/user/configuring/> |
+| <https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new> | <https://eslint.org/docs/latest/user/configure/configuration-files-new> |
+| <https://eslint.org/docs/latest/user-guide/configuring/configuration-files> | <https://eslint.org/docs/latest/users/configure/configuration-files> |
+| <https://eslint.org/docs/latest/user-guide/configuring/language-options> | <https://eslint.org/docs/latest/users/configure/language-options> |
+| <https://eslint.org/docs/latest/user-guide/configuring/rules> | <https://eslint.org/docs/latest/users/configure/rules> |
+| <https://eslint.org/docs/latest/user-guide/configuring/plugins> | <https://eslint.org/docs/latest/users/configure/plugins> |
+| <https://eslint.org/docs/latest/user-guide/configuring/ignoring-code> | <https://eslint.org/docs/latest/users/configure/ignore> |
+| <https://eslint.org/docs/latest/user-guide/command-line-interface> | <https://eslint.org/docs/latest/users/command-line-interface> |
+| <https://eslint.org/docs/latest/user-guide/formatters/> | <https://eslint.org/docs/latest/users/formatters/> |
+| <https://eslint.org/docs/latest/user-guide/integrations> | <https://eslint.org/docs/latest/users/integrations> |
+| <https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0> | <https://eslint.org/docs/latest/user/migrate-to-8.0.0> |
+| <https://eslint.org/docs/latest/user-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/users/> |
+| <https://eslint.org/docs/latest/developer-guide/architecture/> | <https://eslint.org/docs/latest/maintain/architecture/> |
+| <https://eslint.org/docs/latest/developer-guide/source-code> |  <https://eslint.org/docs/latest/maintain/development-environment> |
+| <https://eslint.org/docs/latest/developer-guide/development-environment> |  <https://eslint.org/docs/latest/maintain/development-environment> |
+| <https://eslint.org/docs/latest/developer-guide/unit-tests> | <https://eslint.org/docs/latest/maintain/tests> |
+| <https://eslint.org/docs/latest/extend/working-with-rules> | <https://eslint.org/docs/latest/extend/custom-rules> |
+| <https://eslint.org/docs/latest/developer-guide/working-with-plugins> | <https://eslint.org/docs/latest/extend/plugins> |
+| <https://eslint.org/docs/latest/developer-guide/working-with-custom-formatters> | <https://eslint.org/docs/latest/extend/custom-formatters> |
+| <https://eslint.org/docs/latest/developer-guide/working-with-custom-parsers> | <https://eslint.org/docs/latest/custom-parsers> |
+| <https://eslint.org/docs/latest/developer-guide/nodejs-api> | <https://eslint.org/docs/latest/extend/nodejs-api> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/> | <https://eslint.org/docs/latest/contribute/> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs> | <https://eslint.org/docs/latest/contribute/report-bugs> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/new-rules> | <https://eslint.org/docs/latest/contribute/new-rule> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/rule-changes> | <https://eslint.org/docs/latest/contribute/rule-change> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/changes> | <https://eslint.org/docs/latest/contribute/change> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues> | <https://eslint.org/docs/latest/contribute/work-on-issue> |
+| <https://eslint.org/docs/latest/developer-guide/contributing/pull-requests> | <https://eslint.org/docs/latest/contribute/pull-requests> |
+| <https://eslint.org/docs/latest/developer-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/extend/**> |
+| <https://eslint.org/docs/latest/maintainer-guide/> | <https://eslint.org/docs/latest/maintain/> |
+| <https://eslint.org/docs/latest/maintainer-guide/issues> | <https://eslint.org/docs/latest/maintain/manage-issues> |
+| <https://eslint.org/docs/latest/maintainer-guide/pullrequests> |  <https://eslint.org/docs/latest/maintain/review-pull-requests> |
+| <https://eslint.org/docs/latest/maintainer-guide/releases> | <https://eslint.org/docs/latest/maintain/manage-releases> |
+| <https://eslint.org/docs/latest/maintainer-guide/governance> | <https://eslint.org/docs/latest/contribute/governance> |
+| <https://eslint.org/docs/latest/maintainer-guide/**> (any other pages not in sidebar) | <https://eslint.org/docs/latest/maintain/**> |
 
 ## Drawbacks
 
@@ -193,6 +288,7 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 ## Open Questions
 
 1. Is there a way to automatically change all the internal links that'll be broken by these updates?
+   - A: [No (link with explanation)](https://github.com/eslint/rfcs/pull/97#discussion_r1003895871)
 1. Can you create a side navigation folder that is not also a page?
 1. How to make section landing pages navigable from the side table of contents? (For example, the proposed page "Use ESLint in Your Project landing page")
 
@@ -226,7 +322,7 @@ I would likely need help with the following tasks:
 
 ### Why Rename Pages with Active Verb Phrases?
 
-This outline proposes renaming various titles to use active verb phrases instead of the current  gerund-based page name structure (ex. changing a page title from “Managing Issues” → “Manage Issues”). This is following a general technical writing best practice of avoiding gerunds in titles. For more information, refer to [this blog post about the subject](https://www.google.com/url?q=https://www.writethedocs.org/blog/newsletter-october-2022/%23gerunds-in-headings&sa=D&source=docs&ust=1665539063991039&usg=AOvVaw2HTT7RUQYPCcUenwVv0-Zt).
+This outline proposes renaming various titles to use active verb phrases instead of the current gerund-based page name structure (ex. changing a page title from “Managing Issues” → “Manage Issues”). This is following a general technical writing best practice of avoiding gerunds in titles. For more information, refer to [this blog post about the subject](https://www.google.com/url?q=https://www.writethedocs.org/blog/newsletter-october-2022/%23gerunds-in-headings&sa=D&source=docs&ust=1665539063991039&usg=AOvVaw2HTT7RUQYPCcUenwVv0-Zt).
 
 ### Will This Information Architecture Update Include Creating New Content?
 

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -51,7 +51,6 @@ The newly proposed information architecture should consist of the following sect
   - Hidden in sidebar
 - [NO CHANGE] Getting Started
   - Current page: [Getting Started](https://eslint.org/docs/latest/user-guide/getting-started)
-  - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: "Use ESLint in Your Project" documentation update** of the documentation update project.
 - [NO CHANGE] Core Concepts
   - Current page: [Core Concepts](https://eslint.org/docs/latest/user-guide/core-concepts)
 - [RENAME PAGE] Configure
@@ -90,7 +89,7 @@ The newly proposed information architecture should consist of the following sect
   - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 4: "Extend ESLint" documentation update** of the documentation update project.
 - [RENAME & REFACTOR PAGE] Create Plugins
   - Current page: [Working with Plugins](https://eslint.org/docs/latest/developer-guide/working-with-plugins)
-  - As noted below, convert the "Processors in Plugins" section into separate page "Custom Processors
+  - As noted below, convert the "Processors in Plugins" section into separate page "Custom Processors"
   - Add overview-style content at the top of the page explaining that this page explains how to bundle together the various parts of a plugin, and then publish it.
 - [RENAME PAGE] Custom Rules
   - Current page: [Working with Rules](https://eslint.org/docs/latest/developer-guide/working-with-rules)
@@ -161,7 +160,7 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
 - [NEW PAGE(S)] Any other technical pages for maintainers
   - I don’t have any thoughts on what these should be right now. I would defer to the core maintainers on what they think other maintainers should know.
-  - I think that these additional technical pages would make sense to include in **Phase 5: "Maintain ESLint" documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).
+  - I think that these additional technical pages would make sense to include in **Phase 5: "Maintain ESLint" documentation updates** of [the documentation update project](https://github.com/eslint/eslint/issues/16365).
 
 ### New Sidebar (summary)
 

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -30,7 +30,7 @@ These personas are:
 
 While making broad IA changes to reorient the documentation around these personas, I also propose smaller, more cosmetic changes to the documentation website's information architecture to better align it with technical documentation best practices, like making page titles verb phrases and avoiding gerunds.
 
-While I believe that the ESLint documentation currently serves these personas relatively well, TODO: but blah blah why there's an issue w the current state of things.
+As a result of these changes, the ESLint documentation all personas will be able to better navigate the documentation and better complete the tasks that they're using ESLint for.
 
 <!-- Why are we doing this? What use cases does it support? What is the expected
 outcome? -->

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -136,8 +136,10 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
 - [MOVE & RENAME PAGE] Submit a Pull Request
   - Current page: [Pull Requests](https://eslint.org/docs/latest/developer-guide/contributing/pull-requests)
+- [NEW PAGE] Code of Conduct
+  - Takes current content from the [Read the Code of Conduct section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#read-the-code-of-conduct). Worth breaking out into its own page so content not only on the hidden landing page.
 - [NEW PAGE] Report Security Vulnerabilities
-  - Tales current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page for discoverability and SEO for an important subject.
+  - Takes current content from the [Reporting a Security Vulnerability section on the Contributing page](https://eslint.org/docs/latest/developer-guide/contributing/#reporting-a-security-vulnerability). Worth breaking out into its own page so that content not only on the hidden landing page and for discoverability and SEO for an important subject.
   - NOTE: Should be added, but not part of the initial IA project. Probably can be done as a one-off task or group in with one of the project phases.
 - [MOVE PAGE] Governance
   - Current page: [Governance](https://eslint.org/docs/latest/maintainer-guide/governance)
@@ -196,6 +198,7 @@ With the above changes, the left-hand side navigation will look like:
   - Run the Tests
   - Work on Issues
   - Submit a Pull Request
+  - Code of Conduct
   - Report Security Vulnerabilities
   - Governance
 - Maintain ESLint (landing page)

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -95,6 +95,7 @@ The newly proposed information architecture should consist of the following sect
   - Add overview-style content at the top of the page explaining that this page explains how to bundle together the various parts of a plugin, and then publish it.
 - [RENAME PAGE] Custom Rules
   - Current page: [Working with Rules](https://eslint.org/docs/latest/developer-guide/working-with-rules)
+  - NOTE: As fast follow, move some of the contents of this page focused on creating a core rule to the "Contribute to ESLint" section. Exact details TBD.
 - [RENAME PAGE] Custom Formatters
   - Current page: [Working with Custom Formatters](https://eslint.org/docs/latest/developer-guide/working-with-custom-formatters)
 - [RENAME PAGE] Custom Parsers

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -7,9 +7,9 @@
 
 ## Summary
 
-This document contains proposed changes to the information architecture in the ESLint documentation website, <https://eslint.org/docs>.
+This document contains proposed changes to the information architecture (IA) in the ESLint documentation website, <https://eslint.org/docs>.
 
-On a high level, the proposed information architecture breaks the content into the following sections:
+On a high level, the proposed IA breaks the content into the following sections:
 
 - Use ESLint in Your Project: A refactor of the current [User Guide](https://eslint.org/docs/latest/user-guide/)
 - Extend ESLint: A refactor of the current [Developer Guide](https://eslint.org/docs/latest/developer-guide/), with some content moved to the section Maintain ESLint and Community Contributions
@@ -18,30 +18,31 @@ On a high level, the proposed information architecture breaks the content into t
 
 ## Motivation
 
-TODO: need to think on this one more than 'cuz nicholas said so'
+The motivation of this proposed change to the ESLint documentation IA is to reorient it around the core personas of the ESLint community.
+
+These personas are:
+
+- **The User**: Someone who wants to use ESLint as it currently exists, including plugins.
+- **The Extender**: Someone who wants to extend the functionality of ESLint by creating a plugin, custom formatter, custom parser, sharable configuration, etc.
+- **The Maintainer**: Someone who wants to contribute to the core ESLint project.
+- **The Community Contributor**: Someone who wants to make a small change to the core ESLint project, add a small change to the docs, or raise a Github issue.
+  - Note: We haven't previously talked about this persona. However, after reading through   all the docs and considering the ESLint ecosystem, I think it makes sense to break this out as a separate persona.
+
+While making broad IA changes to reorient the documentation around these personas, I also propose smaller, more cosmetic changes to the documentation website's information architecture to better align it with technical documentation best practices, like making page titles verb phrases and avoiding gerunds.
+
+While I believe that the ESLint documentation currently serves these personas relatively well, TODO: but blah blah why there's an issue w the current state of things.
+
 <!-- Why are we doing this? What use cases does it support? What is the expected
 outcome? -->
 
 ## Detailed Design
 
-TODO: note abt how this isn't bulk of RFC. more like technical considerations
-<!--
-   This is the bulk of the RFC.
-
-   Explain the design with enough detail that someone familiar with ESLint
-   can implement it by reading this document. Please get into specifics
-   of your approach, corner cases, and examples of how the change will be
-   used. Be sure to define any new terms in this section.
--->
+N/A. All changes documentation related.
 
 ## Documentation
 
 The newly proposed information architecture should consist of the following sections and pages:
 
-<!--
-    How will this RFC be documented? Does it need a formal announcement
-    on the ESLint blog to explain the motivation?
--->
 ### [REFACTOR SECTION]  Use ESLint in Your Project
 
 - [RENAME SECTION] Use ESLint in Your Project
@@ -108,7 +109,7 @@ The newly proposed information architecture should consist of the following sect
   - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
 - [NEW PAGE(S)] Any other technical pages for maintainers
   - I don’t have any thoughts on what these should be right now. I would defer to the core maintainers on what they think other maintainers should know.
-  - I think that these additional technical pages would make sense to include in **Phase 5: “Maintain ESLint” documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).  
+  - I think that these additional technical pages would make sense to include in **Phase 5: “Maintain ESLint” documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).
   - NOTE: Maybe should be added, but not part of the initial IA project.
 - [MOVE PAGE] Run the Tests
   - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
@@ -146,11 +147,16 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 
 ## Drawbacks
 
-TODO: breaking user experience
+Potential drawbacks of this documentation update include:
+
+- Breaking user experience from the current documentation
+- Users potentially do not find the new information architecture more clear
+- Opportunity cost. Time spent on the information architecture updates could be spent on more impactful documentation tasks.
+
 <!--
     Why should we *not* do this? Consider why adding this into ESLint
-    might not benefit the project or the community. Attempt to think 
-    about any opposing viewpoints that reviewers might bring up. 
+    might not benefit the project or the community. Attempt to think
+    about any opposing viewpoints that reviewers might bring up.
 
     Any change has potential downsides, including increased maintenance
     burden, incompatibility with other tools, breaking existing user
@@ -170,6 +176,8 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 
 ## Alternatives
 
+- Do not change the information architecture, but only
+
 <!--
     What other designs did you consider? Why did you decide against those?
 
@@ -180,7 +188,9 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 ## Open Questions
 
 1. Is it possible to have an always-opened folder named ‘Reference’ in which we put all these pages under? I.e similar to the “User Guide” folder, but as a subsection of the “User Guide” folder.
-2. TODO: more about if containers can not be pages as well.
+2. Is there a way to automatically change all the internal links that'll be broken by these updates?
+3. Can you create a side navigation folder that is not also a page?
+
 <!--
     This section is optional, but is suggested for a first draft.
 
@@ -197,6 +207,7 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 I would likely need help with the following tasks:
 
 - Technical implementation details of how to handle redirects
+- I may need some help with updating the side navigation.
 - Investigation of if there's a way to automate changing the internal link paths
 
 <!--
@@ -227,6 +238,7 @@ No. Additional content is to be created in Phases 3+ of the [documentation updat
 ## Related Discussions
 
 This work corresponds to **Phase 2: High-level information architecture update** of the [documentation update project](https://github.com/eslint/eslint/issues/16365).
+
 <!--
     This section is optional but suggested.
 

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -47,9 +47,9 @@ The newly proposed information architecture should consist of the following sect
 
 - [RENAME SECTION] Use ESLint in Your Project
   - Rename of current section User Guide
-- [EXPOSE IN IA] Use ESLint in Your Project landing page
+- [NO CHANGE] Use ESLint in Your Project landing page
   - Current page: [User Guide landing page](https://eslint.org/docs/latest/user-guide/)
-  - Make accessible by clicking "Use ESLint in Your Project" in the side table of contents. Currently can only navigate to this page by accessing the URL.
+  - Hidden in sidebar
 - [NO CHANGE] Getting Started
   - Current page: [Getting Started](https://eslint.org/docs/latest/user-guide/getting-started)
   - NOTE: I think there’s further work that can be done to improve the getting started experience, but do not want to touch the subject as part of the information architecture changes project. Investigate further in **Phase 3: “Use ESLint in Your Project” documentation update** of the documentation update project.
@@ -78,8 +78,10 @@ The newly proposed information architecture should consist of the following sect
 
 ### [REFACTOR SECTION]  Extend ESLint
 
-- [EXPOSE IN IA] Extend ESLint landing page
-  - Repurpose the current section landing page [Developer Guide](https://eslint.org/docs/latest/developer-guide/) to be exposed in the side navigation and with the below content.
+- [NO CHANGE] Extend ESLint landing page
+  - Current page:  [Developer Guide](https://eslint.org/docs/latest/developer-guide/)
+  - Hidden in sidebar
+- [NEW PAGE] Ways to Extend ESLint
   - Contain overview type content explaining the various ways that you can extend ESLint:
     - Create Plugins
     - Create Custom Rules
@@ -111,6 +113,7 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 
 - [MOVE & RENAME PAGE] Community Contributions section landing page
   - Current page: [Contributing](https://eslint.org/docs/latest/developer-guide/contributing/)
+  - Hidden in sidebar
 - [MOVE & RENAME PAGE] Report Bugs
   - Current page: [Bug Reporting](https://eslint.org/docs/latest/developer-guide/contributing/reporting-bugs)
 - [MOVE & RENAME PAGE] Propose a New Rule
@@ -131,9 +134,9 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 
 ### [REFACTOR SECTION] Maintain ESLint
 
-- [EXPOSE IN IA] Maintain ESLint section landing page
-  - Repurpose the current section landing page [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide) to be exposed in the side navigation and with the above content.
-  - NOTE: Should be added, but not part of the initial IA project. Add in **Phase 5: “Maintain ESLint” documentation update** of the documentation update project.
+- [NO CHANGE] Maintain ESLint section landing page
+  - Current page: [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide)
+  - Hidden in sidebar
 - [MOVE PAGE] Architecture
   - Current page: [Architecture](https://eslint.org/docs/latest/developer-guide/architecture/)
   - Note: in a previous conversation with Nicholas, he mentioned to me that this page is pretty out-of date.
@@ -149,13 +152,12 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - NOTE: Maybe should be added, but not part of the initial IA project.
 - [MOVE PAGE] Run the Tests
   - Current page: [Unit Tests](https://eslint.org/docs/latest/developer-guide/unit-tests)
-- [NEW SECTION] Project Management
-  - [MOVE & RENAME PAGE] Manage Issues
-    - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
-  - [MOVE & RENAME PAGE] Review Pull Requests
-    - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
-  - [MOVE & RENAME PAGE] Manage Releases
-    - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
+- [MOVE & RENAME PAGE] Manage Issues
+  - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
+- [MOVE & RENAME PAGE] Review Pull Requests
+  - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
+- [MOVE & RENAME PAGE] Manage Releases
+  - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
 
 ### New Sidebar (summary)
 
@@ -196,10 +198,9 @@ With the above changes, the left-hand side navigation will look like:
   - Architecture
   - Set up a Development Environment
   - Run the Tests
-  - Project Management
-    - Manage Issues
-    - Review Pull Requests
-    - Manage Releases
+  - Manage Issues
+  - Review Pull Requests
+  - Manage Releases
 
 ### HTTP Redirects
 
@@ -290,7 +291,9 @@ HTTP redirects from existing content URL paths to the new content URL paths must
 1. Is there a way to automatically change all the internal links that'll be broken by these updates?
    - A: [No (link with explanation)](https://github.com/eslint/rfcs/pull/97#discussion_r1003895871)
 1. Can you create a side navigation folder that is not also a page?
+   - A: [No (link with explanation)](https://github.com/eslint/rfcs/pull/97#discussion_r1003896032)
 1. How to make section landing pages navigable from the side table of contents? (For example, the proposed page "Use ESLint in Your Project landing page")
+   - [Cannot for top level landing pages for design decision reasons (link with explanation)](https://github.com/eslint/rfcs/pull/97#discussion_r1007459580)
 
 <!--
     This section is optional, but is suggested for a first draft.

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -335,7 +335,8 @@ This outline proposes renaming various titles to use active verb phrases instead
 
 ### Will This Information Architecture Update Include Creating New Content?
 
-No. Additional content is to be created in Phases 3+ of the [documentation update project](https://github.com/eslint/eslint/issues/16365).
+No. Additional content is to be created in Phases 3+ of the [documentation update project](https://github.com/eslint/eslint/issues/16365). This includes documentation for the [newly proposed "Integrator" persona](https://github.com/eslint/rfcs/pull/97#discussion_r1012138932),
+to be completed in phase 6 of the documentation update project.
 
 <!--
     This section is optional but suggested.

--- a/designs/2022-docs-information-architecture-update/README.md
+++ b/designs/2022-docs-information-architecture-update/README.md
@@ -123,12 +123,15 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
   - Current page: [Proposing a Rule Change](https://eslint.org/docs/latest/developer-guide/contributing/#:~:text=Proposing%20a-,Rule%20Change,-Want%20to%20make)
 - [MOVE & RENAME PAGE] Request a Change
   - Current page: [Change Requests](https://eslint.org/docs/latest/developer-guide/contributing/changes)
-- [MOVE & RENAME PAGE] Manage Issues
-  - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
-- [MOVE & RENAME PAGE] Review Pull Requests
-  - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
-- [MOVE & RENAME PAGE] Manage Releases
-  - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
+- [MOVE PAGE] Architecture
+  - Current page: [Architecture](https://eslint.org/docs/latest/developer-guide/architecture/)
+  - Note: in a previous conversation with Nicholas, he mentioned to me that this page is pretty out-of date.
+  - There should probably be a future unit of work to refactor this page.
+  - However, it’s not included in the information architecture updates.
+- [MOVE & REFACTOR PAGE] Set up Development Environment
+  - Consolidate the pages [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code) and [Set up a Development Environment](https://eslint.org/docs/latest/developer-guide/development-environment)
+  - Getting the source code is basically just a step in the process of setting up the development environment. Therefore, these two pages should be consolidated
+  - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
 - [MOVE & RENAME PAGE] Work on Issues
   - Current page: [Working on Issues](https://eslint.org/docs/latest/developer-guide/contributing/working-on-issues)
 - [MOVE & RENAME PAGE] Submit a Pull Request
@@ -144,15 +147,12 @@ New top-level section of the docs based on the [Contributing](https://eslint.org
 - [NO CHANGE] Maintain ESLint section landing page
   - Current page: [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide)
   - Hidden in sidebar
-- [MOVE PAGE] Architecture
-  - Current page: [Architecture](https://eslint.org/docs/latest/developer-guide/architecture/)
-  - Note: in a previous conversation with Nicholas, he mentioned to me that this page is pretty out-of date.
-  - There should probably be a future unit of work to refactor this page.
-  - However, it’s not included in the information architecture updates.
-- [MOVE & REFACTOR PAGE] Set up Development Environment
-  - Consolidate the pages [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code) and [Set up a Development Environment](https://eslint.org/docs/latest/developer-guide/development-environment)
-  - Getting the source code is basically just a step in the process of setting up the development environment. Therefore, these two pages should be consolidated
-  - Also the Directory Structure section on the [Getting the Source Code](https://eslint.org/docs/latest/developer-guide/source-code#directory-structure) page should be moved toward the bottom of the new Set up a Development Environment page.
+- [MOVE & RENAME PAGE] Manage Issues
+  - Current page: [Managing Issues](https://eslint.org/docs/latest/maintainer-guide/issues)
+- [MOVE & RENAME PAGE] Review Pull Requests
+  - Current page: [Reviewing Pull Requests](https://eslint.org/docs/latest/maintainer-guide/pullrequests)
+- [MOVE & RENAME PAGE] Manage Releases
+  - Current page: [Managing Releases](https://eslint.org/docs/latest/maintainer-guide/releases)
 - [NEW PAGE(S)] Any other technical pages for maintainers
   - I don’t have any thoughts on what these should be right now. I would defer to the core maintainers on what they think other maintainers should know.
   - I think that these additional technical pages would make sense to include in **Phase 5: “Maintain ESLint” documentation updates**of [the documentation update project](https://github.com/eslint/eslint/issues/16365).


### PR DESCRIPTION
## Summary

This document contains proposed changes to the information architecture in the ESLint documentation website, <https://eslint.org/docs>.

On a high level, the proposed information architecture breaks the content into the following sections:

- Use ESLint in Your Project: A refactor of the current [User Guide](https://eslint.org/docs/latest/user-guide/)
- Extend ESLint: A refactor of the current [Developer Guide](https://eslint.org/docs/latest/developer-guide/), with some content moved to the section Maintain ESLint and Community Contributions
- Maintain ESLint: Expansion of current [Maintainer Guide](https://eslint.org/docs/latest/maintainer-guide/), with some content taken from the current ‘Developer Guide’.
- Community Contributions: Expansion of the current [Contributing section](https://eslint.org/docs/latest/developer-guide/contributing/) of the Developer Guide.

## Related Issues

https://github.com/eslint/eslint/issues/16365
