### PR TITLE
build: Update tweet functionality

### DIFF
--- a/.github/workflows/tweet-rfc-update.yml
+++ b/.github/workflows/tweet-rfc-update.yml
@@ -20,7 +20,7 @@ jobs:
 
   tweetMerge:
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && github.event.pull_request.merged
+    if: github.event.action == 'closed' && github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'Final Commenting')
     steps:
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This update our tweet functionality so it only tweets out a merged pull request if one of the labels is "Final Commenting". This will prevent tweets for PRs like this one, that aren't RFCs but will be merged into the repo just the same.