### PR TITLE
feat!: skip warnings cli flag

### DIFF
--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -18,10 +18,11 @@ intended outcome of this RFC is to allow users to not run these rules when unnec
 A common use-case of the `warn` level is to report errors to the developer in their IDE,
 but to completely ignore it when running ESLint on the command line via the `--quiet` flag.
 When running with many rules set to the `warn` level, this can cause a significant amount
-of overhead on ESLint runtime. On an example large codebase, I found that by disabling all
-rules set to warn, I was able to reduce ESLint runtime from 4 minutes and 39 seconds to just
-22 seconds. As the `warn` rules are entirely ignored in this situation, this is a substantial
-amount of wasted time and resources that could be avoided.
+of overhead on ESLint runtime. On an example large codebase with 154988 lines of TypeScript
+code, I found that by disabling all rules set to warn, I was able to reduce ESLint runtime
+from 4 minutes and 39 seconds to just 22 seconds. As the `warn` rules are entirely ignored
+in this situation, this is a substantial amount of wasted time and resources that could be
+avoided.
 
 ## Detailed Design
 
@@ -38,8 +39,8 @@ The flag would be implemented by passing a predicate function that only returns 
 rules that have been set to `error`, thus filtering out any that are marked as `warn`.
 
 The check for unused `eslint-disable` directives (`--report-unused-disable-directives`)
-should continue to mark `warn` rules as used, even when running with `--skip-warnings`.
-As the rules are not actually run, an assumption would have to be made that all directives
+should continue to mark `warn` rules as used, even when running with `--quiet`. As the
+rules are not actually run, an assumption would have to be made that all directives
 on rules marked `warn` are used when in this mode. This is a reasonable assumption, as
 the user likely does not expect `warn` flags to be touched at all in this mode.
 

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -1,0 +1,129 @@
+- Repo: eslint/eslint
+- Start Date: 2023-01-16
+- RFC PR: (leave this empty, to be filled in later)
+- Authors: Maddy Miller
+
+# Only run reporting lint rules
+
+## Summary
+
+Currently, ESLint will run all rules that are not marked as `off` in the configuration.
+This RFC proposes adding a way to configure which rules are actually run, to reduce linting
+time and better match the reporting outcome. Currently, when a rule is marked as `warn`,
+ESLint will still run the rule but not report the results when run under `--quiet`. The
+intended outcome of this RFC is to allow users to not run these rules when unnecessary.
+
+## Motivation
+
+A common use-case of the `warn` level is to report errors to the developer in their IDE,
+but to completely ignore it when running ESLint on the command line via the `--quiet` flag.
+When running with many rules set to the `warn` level, this can cause a significant amount
+of overhead on ESLint runtime. On an example large codebase, I found that by disabling all
+rules set to warn, I was able to reduce ESLint runtime from 4 minutes and 39 seconds to just
+22 seconds. As the `warn` rules are entirely ignored in this situation, this is a substantial
+amount of wasted time and resources that could be avoided.
+
+## Detailed Design
+
+The proposed implementation is to add a `--skip-warnings` flag to ESLint that will skip
+running any rules that are set to the `warn` level. This will be a CLI flag only, as it
+doesn't make sense to have this flag in a configuration file. This flag would implicitly
+imply the `--quiet` flag, given if the `warn` rules are not run, they will not be outputted
+to reporters.
+
+From an API perspective, this would be implemented by a predicate function that acts as
+a filter on which rules should be run. The predicate would take the rule configuration,
+and return whether the rule should be run. For simplicity, this function should not be
+given rules marked as `off`, as if this function handled existing behavior then users of the
+API would have to mimic that when attempting to extend it.
+
+The flag would be implemented by passing a predicate function that only returns true for
+rules that have been set to `error`, thus filtering out any that are marked as `warn`.
+
+The check for unused `eslint-disable` directives (`--report-unused-disable-directives`)
+should continue to mark `warn` rules as used, even when running with `--skip-warnings`.
+
+The `--max-warnings` flag should disable the `--skip-warnings` flag, as it requires that
+`warn` rules are run to know the current number of reported warnings.
+
+## Documentation
+
+Both the flag and API would make sense to document. As they are relatively simple additions,
+they would be documented inline with the rest of the CLI and API documentation. Due to the
+potentially major performance improvements for many setups, I feel mentioning it in the
+release blog post, alongside the potential benefits, would be a good idea to spread awareness.
+
+## Drawbacks
+
+This change adds a new command line flag, as well as a new API method. This adds further
+maintenance burden. However, the implementation is relatively simple, and the benefits
+are significant.
+
+Another potential drawback around this specific implementation is that the existence of
+both `--quiet` and `--skip-warnings` might be confusing to some users, however this can be
+partially alleviated by updating the `--quiet` docs to mention that warnings will still be
+run, and to use `--skip-warnings` instead to not run them.
+
+## Backwards Compatibility Analysis
+
+The proposed solution does not cause any compatibility issues, as all functionality is
+implemented via new APIs and command line flags. Existing users will be unaffected
+by this change.
+
+## Alternatives
+
+### Implement this into `--quiet` instead of a new flag
+
+This alternative would still require the same API changes, but would instead implement
+this behavior into the `--quiet` flag. This would be a breaking change, as it would
+change the behavior of `--quiet` to not run `warn` rules. The upside of this alternative
+would be that it's less confusing to users. This would presumably need to wait for ESLint 9.
+
+Another downside of this alternative is that it would introduce confusion around the
+`--max-warnings` flag and other checks that require warnings to run. Currently the quiet
+flag works fine alongside these. If we were to implement this into the quiet flag, we would
+have to either break that functionality, or have the quiet flag only sometimes stop actual
+running depending on what other flags are in use, which is confusing and unclear.
+
+### Expose more power via the CLI flag
+
+Given the API takes a predicate, another alternative would be to also expose this power
+to the CLI. This would allow users to specify their own predicate function, which would
+allow for more complex filtering. The downside to this change is that it's vastly more
+complex for both the end user and to implement. As the API side of this would be done
+anyway, this could be implemented alongside the current proposal in the future if necessary.
+However, I feel the simple option as outlined in this proposal that covers the majority
+use-case is ideal to keep as a flag either way.
+
+## Open Questions
+
+### Flag naming
+
+Whether `--skip-warnings` is the best name for the flag is still an open question. I feel it's
+the most clear around the base purpose, however I'm open to hearing other suggestions.
+
+### Are there any other considerations I've missed
+
+In the proposal I've outlined two checks that require warnings to run, however I'm not
+familiar with all internal and external features of ESLint, so might have missed some other
+checks that we need to ensure still function correctly with this flag.
+
+## Help Needed
+
+I'm not entirely familiar with the ESLint internals, but would be willing to at least
+partially implement this if given guidance on the specific areas of code that would need
+to be changed.
+
+## Frequently Asked Questions
+
+<!--
+    This section is optional but suggested.
+
+    Try to anticipate points of clarification that might be needed by
+    the people reviewing this RFC. Include those questions and answers
+    in this section.
+-->
+
+## Related Discussions
+
+https://github.com/eslint/eslint/issues/16450

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -48,6 +48,19 @@ should verify that the `rulePredicate` option is a function, and replace it with
 function if not. `processOptions` in `eslint-helpers.js` should also perform a validation check
 that the `rulePredicate` option is a function.
 
+The new `rulePredicate` function when implemented would look like this, using the `--quiet` flag
+rules outlined in this RFC as an example:
+
+```typescript
+linter.verifyAndFix(text, configs, {
+    rulePredicate: ({ ruleId: string, rule: Rule, severity: number }) => {
+        return severity === 2;
+    }
+});
+```
+
+This predicate would return true for all rules which have a severity of 2 (error).
+
 The alteration to the `--quiet` flag would be implemented by passing a predicate function
 to the API that only returns true for rules that have been set to `error`, thus filtering
 out any that are marked as `warn`.
@@ -55,15 +68,14 @@ out any that are marked as `warn`.
 The check for unused `eslint-disable` directives (`--report-unused-disable-directives`)
 should continue to mark `warn` rules as used, even when running with `--quiet`. As the
 rules are not actually run, an assumption would have to be made that all directives
-on rules marked `warn` are used when in this mode. This is a reasonable assumption, as
-the user likely does not expect `warn` flags to be touched at all in this mode.
+on rules marked false by the predicate are used when in this mode. This is a reasonable
+assumption, as the user likely does not expect `warn` flags to be touched at all in this mode.
 
 In cases of conflicting flags such as the `--max-warnings` flag, this altered `--quiet` flag
 behavior should be disabled while it is in use. This is to ensure that the `--max-warnings`
 flag continues to work as expected. The predicate API should not be set, and existing
-behavior of filtering the output should be used. This altered behavior should output to the
-console on run that `--quiet` is slower when used alongside flags that require warnings to be
-run, as well as documented.
+behavior of filtering the output should be used. This altered behavior should be documented
+to clarify that it causes warnings to be run despite the `--quiet` flag.
 
 ## Documentation
 

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -35,10 +35,18 @@ and return whether the rule should be run. For simplicity, this function should 
 given rules marked as `off`, as if this function handled existing behavior then users of the
 API would have to mimic that when attempting to extend it.
 
-This API should be added to `VerifyOptions`, and will be passed into and utilized within
-the `runRules` function during the `configuredRules` loop, after the check for disabled
-rules and the rule existing. The `ruleId`, `rule`, rule configuration from `getRuleOptions`,
-and `severity` should be passed into the predicate function as an object.
+In `cli.js`'s `translateOptions` function, the `rulePredicate` option should be assigned to
+a predicate that checks for a `severity` of 2 (error) when the `--quiet` flag is applied, otherwise
+always returns true. In `eslint/flat-eslint.js`, the `rulePredicate` should be taken from
+the `eslintOptions` object, and passed down to the `linter.verifyAndFix` call.
+
+Within `linter.js`, the API should be added to `VerifyOptions`, and will be passed down into and
+utilized within the `runRules` function during the `configuredRules` loop, after the check
+for disabled rules and the rule existing. The `ruleId`, `rule`, rule configuration from `getRuleOptions`,
+and `severity` should be passed into the predicate function as an object. `normalizeVerifyOptions`
+should verify that the `rulePredicate` option is a function, and replace it with an always-true
+function if not. `processOptions` in `eslint-helpers.js` should also perform a validation check
+that the `rulePredicate` option is a function.
 
 The alteration to the `--quiet` flag would be implemented by passing a predicate function
 to the API that only returns true for rules that have been set to `error`, thus filtering

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -35,27 +35,27 @@ and return whether the rule should be run. For simplicity, this function should 
 given rules marked as `off`, as if this function handled existing behavior then users of the
 API would have to mimic that when attempting to extend it.
 
-In `cli.js`'s `translateOptions` function, the `rulePredicate` option should be assigned to
+In `cli.js`'s `translateOptions` function, the `ruleFilter` option should be assigned to
 a predicate that checks for a `severity` of 2 (error) when the `--quiet` flag is applied, otherwise
-always returns true. In `eslint/flat-eslint.js`, the `rulePredicate` should be taken from
+always returns true. In `eslint/flat-eslint.js`, the `ruleFilter` should be taken from
 the `eslintOptions` object, and passed down to the `linter.verifyAndFix` call.
 
 Within `linter.js`, the API should be added to `VerifyOptions`, and will be passed down into and
 utilized within the `runRules` function during the `configuredRules` loop, after the check
 for disabled rules and the rule existing. The `ruleId`, `rule`, rule configuration from `getRuleOptions`,
 and `severity` should be passed into the predicate function as an object. `normalizeVerifyOptions`
-should verify that the `rulePredicate` option is a function, and replace it with an always-true
+should verify that the `ruleFilter` option is a function, and replace it with an always-true
 function if not. `processOptions` in `eslint-helpers.js` should also perform a validation check
-that the `rulePredicate` option is a function.
+that the `ruleFilter` option is a function.
 
-The new `rulePredicate` function when implemented would look like this, using the `--quiet` flag
+The new `ruleFilter` function when implemented would look like this, using the `--quiet` flag
 rules outlined in this RFC as an example:
 
 ```typescript
 linter.verifyAndFix(text, configs, {
-    rulePredicate: ({ ruleId: string, rule: Rule, severity: number }) => {
-        return severity === 2;
-    }
+  ruleFilter: ({ ruleId: string, rule: Rule, severity: number }) => {
+    return severity === 2;
+  },
 });
 ```
 
@@ -81,9 +81,9 @@ to clarify that it causes warnings to be run despite the `--quiet` flag.
 
 ## Documentation
 
-Both the behaviour modification of impacted flags and the API would make sense to document. 
-As they are relatively simple additions, they would be documented inline with the rest 
-of the CLI and API documentation. Due to the potentially major performance improvements for 
+Both the behaviour modification of impacted flags and the API would make sense to document.
+As they are relatively simple additions, they would be documented inline with the rest
+of the CLI and API documentation. Due to the potentially major performance improvements for
 many setups, I feel mentioning it in the release blog post, alongside the potential benefits,
 would be a good idea to spread awareness.
 
@@ -103,7 +103,7 @@ settings.
 This is a breaking change as it alters the behaviour of the `--quiet` flag.
 While the alterations to the quiet flag should not affect the actual outcome of the command,
 as cases where it would are covered by this RFC, it is still worth noting as the behaviour
-is changing. 
+is changing.
 
 ## Alternatives
 

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -59,7 +59,7 @@ linter.verifyAndFix(text, configs, {
 });
 ```
 
-This predicate would return true for all rules which have a severity of 2 (error).
+The predicate acts as a filter on the rules to enable, where a value of `true` allows a rule to remain as configured and a value of `false` would disable a rule. This predicate would return true for all rules which have a severity of 2 (error), effectively filtering out all other rules.
 
 The alteration to the `--quiet` flag would be implemented by passing a predicate function
 to the API that only returns true for rules that have been set to `error`, thus filtering

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -30,7 +30,7 @@ The proposed implementation is to modify the `--quiet` flag so that ESLint will 
 running any rules that are set to the `warn` level.
 
 From an API perspective, this would be implemented by a filter function that filters down to
-which rules should be run. The function would take a list of the rule configuration `(ruleId, severity, rule)`,
+which rules should be run. The function would take a list of the rule configuration `(ruleId, severity)`,
 and return the rule that should be run. For simplicity, this function should not be
 given rules marked as `off`, as if this function handled existing behavior then users of the
 API would have to mimic that when attempting to extend it.
@@ -43,7 +43,7 @@ the `eslintOptions` object, and passed down to the `linter.verifyAndFix` call.
 Within `linter.js`, the API should be added to `VerifyOptions`, and will be passed down into and
 utilized within the `runRules` function before the current `configuredRules` loop. Rather than the
 current configuredRules loop, this should extract the `severity` and `rule` existence checks and
-build a list of `{ ruleId, severity, rule}` objects. This new list should be passed to `filterRules`,
+build a list of `{ ruleId, severity }` objects. This new list should be passed to `filterRules`,
 and the resulting list should be iterated on instead of `configuredRules`.
 
 `normalizeVerifyOptions` should verify that the `filterRules` option is a function, and replace it
@@ -55,7 +55,7 @@ rules outlined in this RFC as an example:
 
 ```typescript
 linter.verifyAndFix(text, configs, {
-  filterRules: (rules: { ruleId: string; rule: Rule; severity: number }[]) => {
+  filterRules: (rules: { ruleId: string; severity: number }[]) => {
     return rules.filter((rule) => rule.severity === 2);
   },
 });

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -70,6 +70,8 @@ should continue to mark `warn` rules as used, even when running with `--quiet`. 
 rules are not actually run, an assumption would have to be made that all directives
 on rules marked false by the predicate are used when in this mode. This is a reasonable
 assumption, as the user likely does not expect `warn` flags to be touched at all in this mode.
+This would also apply to blanket `eslint-disable` directives that disable all rules, which
+should always be assumed to be used while a predicate is passed.
 
 In cases of conflicting flags such as the `--max-warnings` flag, this altered `--quiet` flag
 behavior should be disabled while it is in use. This is to ensure that the `--max-warnings`
@@ -79,27 +81,29 @@ to clarify that it causes warnings to be run despite the `--quiet` flag.
 
 ## Documentation
 
-Both the flag and API would make sense to document. As they are relatively simple additions,
-they would be documented inline with the rest of the CLI and API documentation. Due to the
-potentially major performance improvements for many setups, I feel mentioning it in the
-release blog post, alongside the potential benefits, would be a good idea to spread awareness.
+Both the behaviour modification of impacted flags and the API would make sense to document. 
+As they are relatively simple additions, they would be documented inline with the rest 
+of the CLI and API documentation. Due to the potentially major performance improvements for 
+many setups, I feel mentioning it in the release blog post, alongside the potential benefits,
+would be a good idea to spread awareness.
 
 ## Drawbacks
 
-This change adds a new command line flag, as well as a new API method. This adds further
+This change modifies a command line flag, as well as a new API method. This adds further
 maintenance burden. However, the implementation is relatively simple, and the benefits
 are significant.
 
 As this flag has many interactions with other systems such as `--max-warnings`, further
 maintenance overhead is introduced by having to ensure it behaves correctly between
 the different flags. This would require updating documentation across all flags and relevant
-settings, rather than just the added flag.
+settings.
 
 ## Backwards Compatibility Analysis
 
-The proposed solution does not cause any compatibility issues, as all functionality is
-implemented via new APIs and command line flags. Existing users will be unaffected
-by this change.
+This is a breaking change as it alters the behaviour of the `--quiet` flag.
+While the alterations to the quiet flag should not affect the actual outcome of the command,
+as cases where it would are covered by this RFC, it is still worth noting as the behaviour
+is changing. 
 
 ## Alternatives
 

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -37,7 +37,7 @@ API would have to mimic that when attempting to extend it.
 
 In `cli.js`'s `translateOptions` function, the `ruleFilter` option should be assigned to
 a function that filters to rules with a `severity` of 2 (error) when the `--quiet` flag is applied,
-otherwise always returns true. In `eslint/flat-eslint.js`, the `filterRules` should be taken from
+otherwise always returns true. In `eslint/flat-eslint.js`, the `ruleFilter` should be taken from
 the `eslintOptions` object, and passed down to the `linter.verifyAndFix` call.
 
 Within `linter.js`, the API should be added to `VerifyOptions`, and will be passed down into and

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -1,6 +1,6 @@
 - Repo: eslint/eslint
 - Start Date: 2023-01-16
-- RFC PR: (leave this empty, to be filled in later)
+- RFC PR: <https://github.com/eslint/rfcs/pull/104>
 - Authors: Maddy Miller
 
 # Only run reporting lint rules

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -30,39 +30,36 @@ The proposed implementation is to modify the `--quiet` flag so that ESLint will 
 running any rules that are set to the `warn` level.
 
 From an API perspective, this would be implemented by a filter function that filters down to
-which rules should be run. The function would take a list of the rule configuration `(ruleId, severity)`,
-and return the rule that should be run. For simplicity, this function should not be
+which rules should be run. The function would take `(ruleId, severity)` and return true to
+include a rule or false to exclude it. For simplicity, this function should not be
 given rules marked as `off`, as if this function handled existing behavior then users of the
 API would have to mimic that when attempting to extend it.
 
-In `cli.js`'s `translateOptions` function, the `filterRules` option should be assigned to
-a function that filters to rules with a `severity` of 2 (error) when the `--quiet` flag is applied, otherwise
-acts as an identity function. In `eslint/flat-eslint.js`, the `filterRules` should be taken from
+In `cli.js`'s `translateOptions` function, the `ruleFilter` option should be assigned to
+a function that filters to rules with a `severity` of 2 (error) when the `--quiet` flag is applied,
+otherwise always returns true. In `eslint/flat-eslint.js`, the `filterRules` should be taken from
 the `eslintOptions` object, and passed down to the `linter.verifyAndFix` call.
 
 Within `linter.js`, the API should be added to `VerifyOptions`, and will be passed down into and
-utilized within the `runRules` function before the current `configuredRules` loop. Rather than the
-current configuredRules loop, this should extract the `severity` and `rule` existence checks and
-build a list of `{ ruleId, severity }` objects. This new list should be passed to `filterRules`,
-and the resulting list should be iterated on instead of `configuredRules`.
+utilized within the `runRules` function during the `configuredRules` loop, after the check
+for disabled rules and the rule existing. The `ruleId`, and `severity` should be passed into the
+predicate function as an object. `normalizeVerifyOptions` should verify that the `ruleFilter`
+option is a function, and replace it with an always-true function if not. `processOptions` in
+`eslint-helpers.js` should also perform a validation check that the `ruleFilter` option is a function.
 
-`normalizeVerifyOptions` should verify that the `filterRules` option is a function, and replace it
-with an identity function if not. `processOptions` in `eslint-helpers.js` should also perform a
-validation check that the `filterRules` option is a function.
-
-The new `filterRules` function when implemented would look like this, using the `--quiet` flag
+The new `ruleFilter` function when implemented would look like this, using the `--quiet` flag
 rules outlined in this RFC as an example:
 
 ```typescript
 linter.verifyAndFix(text, configs, {
-  filterRules: (rules: { ruleId: string; severity: number }[]) => {
-    return rules.filter((rule) => rule.severity === 2);
+  ruleFilter: ({ ruleId: string, severity: number }) => {
+    return severity === 2;
   },
 });
 ```
 
 The function acts as a filter on the rules to enable, where removal from the list disables a rule.
-This function would return all rules which have a severity of 2 (error), effectively filtering out
+This function would return true for all rules which have a severity of 2 (error), effectively filtering out
 all other rules.
 
 The check for unused `eslint-disable` directives (`--report-unused-disable-directives`)

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -102,6 +102,10 @@ While the alterations to the quiet flag should not affect the actual outcome of 
 as cases where it would are covered by this RFC, it is still worth noting as the behaviour
 is changing.
 
+For the case of rules with side effects, such as the `react/jsx-uses-vars` rule, these side
+effects will no longer run in quiet mode when set to `warn`. Due to this, users will need to
+update their eslint configuration to ensure that any rules with side effects are set to `error`.
+
 ## Alternatives
 
 ### Implement this via a separate `--skip-warnings` flag

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -71,7 +71,7 @@ rules are not actually run, an assumption would have to be made that all directi
 on rules present only in the un-filtered list are used when in this mode. This is a reasonable
 assumption, as the user likely does not expect `warn` flags to be touched at all in this mode.
 This would also apply to blanket `eslint-disable` directives that disable all rules, which
-should always be assumed to be used while a non-identity filter function is passed.
+should always be assumed to be used when the filter function has not changed the length of the list.
 
 In cases of conflicting flags such as the `--max-warnings` flag, this altered `--quiet` flag
 behavior should be disabled while it is in use. This is to ensure that the `--max-warnings`

--- a/designs/2023-only-run-reporting-rules/README.md
+++ b/designs/2023-only-run-reporting-rules/README.md
@@ -35,8 +35,14 @@ and return whether the rule should be run. For simplicity, this function should 
 given rules marked as `off`, as if this function handled existing behavior then users of the
 API would have to mimic that when attempting to extend it.
 
-The flag would be implemented by passing a predicate function that only returns true for
-rules that have been set to `error`, thus filtering out any that are marked as `warn`.
+This API should be added to `VerifyOptions`, and will be passed into and utilized within
+the `runRules` function during the `configuredRules` loop, after the check for disabled
+rules and the rule existing. The `ruleId`, `rule`, rule configuration from `getRuleOptions`,
+and `severity` should be passed into the predicate function as an object.
+
+The alteration to the `--quiet` flag would be implemented by passing a predicate function
+to the API that only returns true for rules that have been set to `error`, thus filtering
+out any that are marked as `warn`.
 
 The check for unused `eslint-disable` directives (`--report-unused-disable-directives`)
 should continue to mark `warn` rules as used, even when running with `--quiet`. As the
@@ -44,9 +50,12 @@ rules are not actually run, an assumption would have to be made that all directi
 on rules marked `warn` are used when in this mode. This is a reasonable assumption, as
 the user likely does not expect `warn` flags to be touched at all in this mode.
 
-The `--max-warnings` flag should be disabled when the `--quiet` flag is in use, as it requires that
-`warn` rules are run to know the current number of reported warnings. This should provide an
-error when the two flags are used together.
+In cases of conflicting flags such as the `--max-warnings` flag, this altered `--quiet` flag
+behavior should be disabled while it is in use. This is to ensure that the `--max-warnings`
+flag continues to work as expected. The predicate API should not be set, and existing
+behavior of filtering the output should be used. This altered behavior should output to the
+console on run that `--quiet` is slower when used alongside flags that require warnings to be
+run, as well as documented.
 
 ## Documentation
 
@@ -92,13 +101,6 @@ However, I feel the simple option as outlined in this proposal that covers the m
 use-case is ideal to keep as a flag either way.
 
 ## Open Questions
-
-### How to handle conflicting flags
-
-This proposal notes that the `--max-warnings` flag would be disabled under `--quiet`, however
-this might not be the best option. Rather than preventing it working, it might make sense to
-warn the user that this mode will still run the `warn` rules despite being in quiet mode,
-so that a setting like `--max-warnings` can still co-exist with `--quiet`.
 
 ### Are there any other considerations I've missed
 


### PR DESCRIPTION
## Summary

Currently, ESLint will run all rules that are not marked as `off` in the configuration.
This RFC proposes adding a way to configure which rules are actually run, to reduce linting
time and better match the reporting outcome. Currently, when a rule is marked as `warn`,
ESLint will still run the rule but not report the results when run under `--quiet`. The
intended outcome of this RFC is to allow users to not run these rules when unnecessary.

I have a very rough test implementation patch here, https://gist.github.com/me4502/e75e4677d3ff17ad585fcab0ac5dc6e9. It is missing a few things and is not very clean, but was done to assist in writing the design details of the RFC itself.

## Related Issues

<!-- optional: include links to relevant discussions here -->

https://github.com/eslint/eslint/issues/16450