### PR TITLE
feat: add assertion options to RuleTester

### DIFF
--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -17,6 +17,8 @@ The options could be defined on two levels. On `RuleTester`'s `constructor` effe
 
 ## Detailed Design
 
+Recommended variant => 2 - Test method based options
+
 ### Variant 1 - Constructor based options
 
 ```ts

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -276,9 +276,6 @@ While this is true already, it gets slightly more relevant, since now it might r
 
 See also: https://github.com/eslint/eslint/issues/19936
 
-Additionally, since we add the options as a second parameter it might interfere with future additions to the parameters.
-This could by eleviated by renaming the parameter from `assertionOptions` to `options` (either from the start or when the need for different type of options arises).
-
 If we enable the `requireMessage` and `requireLocation` options by default, it would be a breaking change for existing tests that do not follow these assertion requirements yet.
 It is not planned to enable `requireMessage` or `requireLocation` by default.
 

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -1,6 +1,6 @@
 - Repo: https://github.com/eslint/eslint
 - Start Date: 2025-07-10
-- RFC PR: (leave this empty, to be filled in later)
+- RFC PR: https://github.com/eslint/rfcs/pull/137
 - Authors: ST-DDT
 
 # Rule Tester Assertions Options

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -290,7 +290,7 @@ it requires identifying the RuleTester calls in the codebase and might run into 
 
 ## Open Questions
 
-1. Is there a need for disabling scenarios like `valid` or `invalid`?
+~~1. Is there a need for disabling scenarios like `valid` or `invalid`?~~ No, unused scenarios can be omitted using empty arrays. If needed, this option can be added later on.
 2. Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files?
 3. ~~Should we enable the `requireMessage` and `requireLocation` options by default? (Breaking change)~~ No
 4. ~~Do we add a `requireMessageId` option or should we alter the `requireMessage` option to support both message and messageId assertions?~~ Just `requireMessage: boolean | 'message' | 'messageid'`

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -23,8 +23,8 @@ The options could be defined on two levels. On `RuleTester`'s `constructor` effe
 new RuleTester(testerConfig: {...}, assertionOptions: {
     /**
      * Require message assertion for each invalid test case.
-     * If `true`, errors must extend `string | Array<{ message: string } | { messageId: string }>`.
-     * If `'message'`, errors must extend `string | Array<{ message: string }>`.
+     * If `true`, errors must extend `string | RegExp | Array<{ message: string | RegExp } | { messageId: string }>`.
+     * If `'message'`, errors must extend `string | RegExp | Array<{ message: string | RegExp }>`.
      * If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
      * 
      * @default false
@@ -46,8 +46,8 @@ new RuleTester(testerConfig: {...}, assertionOptions: {
 ruleTester.run("rule-name", rule, tests, assertionOptions: {
     /**
      * Require message assertion for each invalid test case.
-     * If `true`, errors must extend `string | Array<{ message: string } | { messageId: string }>`.
-     * If `'message'`, errors must extend `string | Array<{ message: string }>`.
+     * If `true`, errors must extend `string | RegExp | Array<{ message: string | RegExp } | { messageId: string }>`.
+     * If `'message'`, errors must extend `string | RegExp | Array<{ message: string | RegExp }>`.
      * If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
      * 
      * @default false
@@ -68,9 +68,9 @@ ruleTester.run("rule-name", rule, tests, assertionOptions: {
 #### requireMessage
 
 If `requireMessage` is set to `true`, the invalid test case cannot consist of an error count assertion only, but must also include a message assertion. (See below)
-This can be done either by providing only a `string` message, or by using the `message`/`messageId` property of the error object in the `TestCaseError` (Same as the current behavior).
-If `true`, errors must extend `string | Array<{ message: string | RegExp } | { messageId: string }>`.
-If `'message'`, errors must extend `string | Array<{ message: string | RegExp }>`.
+This can be done either by providing only a `string`/`RegExp` message, or by using the `message`/`messageId` property of the error object in the `TestCaseError` (Same as the current behavior).
+If `true`, errors must extend `string | RegExp | Array<{ message: string | RegExp } | { messageId: string }>`.
+If `'message'`, errors must extend `string | RegExp | Array<{ message: string | RegExp }>`.
 If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
 
 ````ts

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -295,7 +295,6 @@ it requires identifying the RuleTester calls in the codebase and might run into 
 3. ~~Should we enable the `requireMessage` and `requireLocation` options by default? (Breaking change)~~ No
 4. ~~Do we add a `requireMessageId` option or should we alter the `requireMessage` option to support both message and messageId assertions?~~ Just `requireMessage: boolean | 'message' | 'messageid'`
 5. Should we add a `strict` option that enables all assertion options by default?
-6. ~~Should we expose `requiredScenarios` as option?~~ No, the users can just use empty arrays.
 
 ## Help Needed
 

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -72,28 +72,30 @@ ruleTester.run("rule-name", rule, tests, assertionOptions: {
 
 ### Shared Logic
 
-If `requireMessage` is set to `true`, the invalid test case cannot consist of an error count assertion only, but must also include a message assertion.
-This can be done either by providing only a `string` message, or by using the `message` property of the error object in the assertion (Same as the current behavior).
-Alternatively, we could alter the `requireMessage` option to `false | true | "message" | "messageId"` (`true` => `"message"`).
+If `requireMessage` is set to `true`, the invalid test case cannot consist of an error count assertion only, but must also include a message assertion. (See below)
+This can be done either by providing only a `string` message, or by using the `message`/`messageId` property of the error object in the `TestCaseError` (Same as the current behavior).
+If `true`, errors must extend `string | Array<{ message: string } | { messageId: string }>`.
+If `'message'`, errors must extend `string | Array<{ message: string }>`.
+If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
 
 ````ts
 ruleTester.run("rule-name", rule, {
     invalid: [
         {
             code: "const a = 1;",
-            errors: 1, // ❌
+            errors: 1, // ❌ Message isn't being checked here
         },
         {
             code: "const a = 2;",
             errors: [
-                "Error message here.", // ✅
+                "Error message here.", // ✅ we only check the error message
             ]
         },
         {
             code: "const a = 3;",
             errors: [
                 {
-                    message: "Error message here.", // ✅
+                    message: "Error message here.", // ✅ we check the error message and potentially other properties
                 }
             ]
         }
@@ -110,19 +112,19 @@ ruleTester.run("rule-name", rule, {
     invalid: [
         {
             code: "const a = 1;",
-            errors: 1, // ❌
+            errors: 1, // ❌ Location isn't checked here
         },
         {
             code: "const a = 2;",
             errors: [
-                "Error message here.", // ❌
+                "Error message here.", // ❌ Location isn't checked here
             ]
         },
         {
             code: "const a = 3;",
             errors: [
                 {
-                    line: 1, // ❌
+                    line: 1, // ❌ Location isn't fully checked here
                     column: 1, 
                     
                 }
@@ -132,7 +134,7 @@ ruleTester.run("rule-name", rule, {
             code: "const a = 4;",
             errors: [
                 {
-                    line: 1, // ✅
+                    line: 1, // ✅ All location properties have been checked
                     column: 1,
                     endLine: 1,
                     endColumn: 12,

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -17,34 +17,6 @@ The options could be defined on two levels. On `RuleTester`'s `constructor` effe
 
 ## Detailed Design
 
-Recommended variant => 2 - Test method based options
-
-### Variant 1 - Constructor based options
-
-```ts
-new RuleTester(testerConfig: {...}, assertionOptions: {
-  /**
-   * Require message assertion for each invalid test case.
-   * If `true`, each error must extend `string | RegExp | { message: string | RegExp } | { messageId: string }`.
-   * If `'message'`, each error must extend `string | RegExp | { message: string | RegExp }`.
-   * If `'messageId'`, each error must extend `{ messageId: string }`.
-   *
-   * @default false
-   */
-  requireMessage: boolean | 'message' | 'messageId';
-  /**
-   * Require full location assertions for each invalid test case.
-   * If `true`, each error must extend `{ line: number, column: number, endLine?: number | undefined, endColumn?: number | undefined }`.
-   * `endLine` or `endColumn` may be absent, if the observed error does not contain these properties.
-   *
-   * @default false
-   */
-  requireLocation: boolean;
-} = {});
-```
-
-### Variant 2 - Test method based options
-
 ```ts
 ruleTester.run("rule-name", rule, {
   assertionOptions?: {
@@ -71,9 +43,7 @@ ruleTester.run("rule-name", rule, {
 });
 ```
 
-### Shared Logic
-
-#### requireMessage
+### requireMessage
 
 If `requireMessage` is set to `true`, the invalid test case cannot consist of an error count assertion only, but must also include a message assertion. (See below)
 This can be done either by providing only a `string`/`RegExp` message, or by using the `message`/`messageId` property of the error object in the `TestCaseError` (Same as the current behavior).
@@ -109,7 +79,7 @@ ruleTester.run("rule-name", rule, {
 });
 ```
 
-#### requireLocation
+### requireLocation
 
 If `requireLocation` is set to `true`, the invalid test case's error validation must include all location assertions such as `line`, `column`, `endLine`, and `endColumn`.
 `endLine` or `endColumn` may be absent or `undefined`, if the observed error does not contain these properties.
@@ -318,9 +288,37 @@ This change should not affect existing ESLint users or plugin developers, as it 
 
 ## Alternatives
 
+### Constructor based options
+
+```ts
+new RuleTester(testerConfig: {...}, assertionOptions: {
+  /**
+   * Require message assertion for each invalid test case.
+   * If `true`, each error must extend `string | RegExp | { message: string | RegExp } | { messageId: string }`.
+   * If `'message'`, each error must extend `string | RegExp | { message: string | RegExp }`.
+   * If `'messageId'`, each error must extend `{ messageId: string }`.
+   *
+   * @default false
+   */
+  requireMessage: boolean | 'message' | 'messageId';
+  /**
+   * Require full location assertions for each invalid test case.
+   * If `true`, each error must extend `{ line: number, column: number, endLine?: number | undefined, endColumn?: number | undefined }`.
+   * `endLine` or `endColumn` may be absent, if the observed error does not contain these properties.
+   *
+   * @default false
+   */
+  requireLocation: boolean;
+} = {});
+```
+
+### ESLint RuleTester Lint-Rule
+
 As an alternative to this proposal, we could add a eslint rule that applies the same assertions, but uses the central eslint config.
 While this would apply the same assertions for all rule testers, it would be a lot more complex to implement and maintain,
 it requires identifying the RuleTester calls in the codebase and might run into issues if the assertions aren't specified inline but via a variable or transformation.
+
+### RuleTester Estimated Error Location
 
 The following issue makes it easier to identify the exact/estimated error location (outside of/more precise than `RuleTester#run`):
 
@@ -329,7 +327,7 @@ The following issue makes it easier to identify the exact/estimated error locati
 ## Open Questions
 
 1. ~~Is there a need for disabling scenarios like `valid` or `invalid`?~~ No, unused scenarios can be omitted using empty arrays. If needed, this option can be added later on.
-2. Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files? Currently, the method level options (variant 2) is the prefered one.
+2. ~~Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files?~~ Currently, the method level options (variant 2) is the prefered one.
 3. ~~Should we enable the `requireMessage` and `requireLocation` options by default? (Breaking change)~~ No
 4. ~~Do we add a `requireMessageId` option or should we alter the `requireMessage` option to support both message and messageId assertions?~~ Just `requireMessage: boolean | 'message' | 'messageid'`
 5. ~~Should we add a `strict` option that enables all assertion options by default?~~ No, currently not planned.

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -147,9 +147,10 @@ ruleTester.run("rule-name", rule, {
 });
 ````
 
+Having this option is optional.
 If `requiredScenarios` is set, the `run` will only require and expect the given scenarios.
-This can only be used for the `run` method, not the constructor, because there should always be at least one valid and one invalid test case.
-The `requiredScenarios` option can be used to omit certain scenarios from the run, e.g. if the user wants to import a set of tests from a different source, that may have other assertion requirements or haven't achieved the quality needed to require the same assertion strictness.
+This can only be used for the `run` method, not the constructor, because there should always be at least one valid and one invalid test case (potentially spread over multiple run calls).
+The `requiredScenarios` option can be used to disable having to provide `valid`/`invalid` scenarios.
 
 ````ts
 ruleTester.run("rule-name", rule, {
@@ -179,6 +180,27 @@ ruleTester.run("rule-name", rule, {
     invalid: [...],
 }, {
     requiredScenarios: ["invalid"]
+});
+````
+
+This option is meant to be combined with the other options, to make sure each test set applies the best applicable assertion coverage.
+
+````ts
+ruleTester.run("rule-name", rule, {
+    valid: [...],
+    invalid: [...],
+};
+ruleTester.run("rule-name", rule, {
+    invalid: [...],
+}, {
+    requiredScenarios: ["invalid"],
+    requireMessage: true,
+});
+ruleTester.run("rule-name", rule, {
+    invalid: [...],
+}, {
+    requiredScenarios: ["invalid"],
+    requireLocation: true,
 });
 ````
 

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -25,16 +25,16 @@ Recommended variant => 2 - Test method based options
 new RuleTester(testerConfig: {...}, assertionOptions: {
   /**
    * Require message assertion for each invalid test case.
-   * If `true`, errors must extend `string | RegExp | Array<{ message: string | RegExp } | { messageId: string }>`.
-   * If `'message'`, errors must extend `string | RegExp | Array<{ message: string | RegExp }>`.
-   * If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
+   * If `true`, each error must extend `string | RegExp | { message: string | RegExp } | { messageId: string }`.
+   * If `'message'`, each error must extend `string | RegExp | { message: string | RegExp }`.
+   * If `'messageId'`, each error must extend `{ messageId: string }`.
    *
    * @default false
    */
   requireMessage: boolean | 'message' | 'messageId';
   /**
    * Require full location assertions for each invalid test case.
-   * If `true`, errors must extend `Array<{ line: number, column: number, endLine?: number | undefined, endColumn?: number | undefined }>`.
+   * If `true`, each error must extend `{ line: number, column: number, endLine?: number | undefined, endColumn?: number | undefined }`.
    * `endLine` or `endColumn` may be absent, if the observed error does not contain these properties.
    *
    * @default false
@@ -50,16 +50,16 @@ ruleTester.run("rule-name", rule, {
   assertionOptions?: {
     /**
      * Require message assertion for each invalid test case.
-     * If `true`, errors must extend `string | RegExp | Array<{ message: string | RegExp } | { messageId: string }>`.
-     * If `'message'`, errors must extend `string | RegExp | Array<{ message: string | RegExp }>`.
-     * If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
+     * If `true`, each error must extend `string | RegExp | { message: string | RegExp } | { messageId: string }`.
+     * If `'message'`, each error must extend `string | RegExp | { message: string | RegExp }`.
+     * If `'messageId'`, each error must extend `{ messageId: string }`.
      *
      * @default false
      */
     requireMessage?: boolean | 'message' | 'messageId';
     /**
      * Require full location assertions for each invalid test case.
-     * If `true`, errors must extend `Array<{ line: number, column: number, endLine?: number | undefined, endColumn?: number | undefined }>`.
+     * If `true`, each error must extend `{ line: number, column: number, endLine?: number | undefined, endColumn?: number | undefined }`.
      * `endLine` or `endColumn` may be absent or undefined, if the observed error does not contain these properties.
      *
      * @default false
@@ -77,9 +77,9 @@ ruleTester.run("rule-name", rule, {
 
 If `requireMessage` is set to `true`, the invalid test case cannot consist of an error count assertion only, but must also include a message assertion. (See below)
 This can be done either by providing only a `string`/`RegExp` message, or by using the `message`/`messageId` property of the error object in the `TestCaseError` (Same as the current behavior).
-If `true`, errors must extend `string | RegExp | Array<{ message: string | RegExp } | { messageId: string }>`.
-If `'message'`, errors must extend `string | RegExp | Array<{ message: string | RegExp }>`.
-If `'messageId'`, errors must extend `Array<{ messageId: string }>`.
+If `true`, each error must extend `string | RegExp | { message: string | RegExp } | { messageId: string }`.
+If `'message'`, each error must extend `string | RegExp | { message: string | RegExp }`.
+If `'messageId'`, each error must extend `{ messageId: string }`.
 
 ```ts
 ruleTester.run("rule-name", rule, {

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -320,6 +320,10 @@ As an alternative to this proposal, we could add a eslint rule that applies the 
 While this would apply the same assertions for all rule testers, it would be a lot more complex to implement and maintain,
 it requires identifying the RuleTester calls in the codebase and might run into issues if the assertions aren't specified inline but via a variable or transformation.
 
+The following issue makes it easier to identify the exact/estimated error location (outside of/more precise than `RuleTester#run`):
+
+- https://github.com/eslint/eslint/issues/19936
+
 ## Open Questions
 
 1. ~~Is there a need for disabling scenarios like `valid` or `invalid`?~~ No, unused scenarios can be omitted using empty arrays. If needed, this option can be added later on.

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -323,10 +323,12 @@ it requires identifying the RuleTester calls in the codebase and might run into 
 ## Open Questions
 
 1. ~~Is there a need for disabling scenarios like `valid` or `invalid`?~~ No, unused scenarios can be omitted using empty arrays. If needed, this option can be added later on.
-2. Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files?
+2. Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files? Currently, the method level options (variant 2) is the prefered one.
 3. ~~Should we enable the `requireMessage` and `requireLocation` options by default? (Breaking change)~~ No
 4. ~~Do we add a `requireMessageId` option or should we alter the `requireMessage` option to support both message and messageId assertions?~~ Just `requireMessage: boolean | 'message' | 'messageid'`
 5. ~~Should we add a `strict` option that enables all assertion options by default?~~ No, currently not planned.
+6. ~~Should we inline the options?~~ No, this might cause issues with alphabetical object properties.
+7. ~~What should the otpions be called?~~ We name it `assertionOptions` to avoid issues with alphabetical object properties. e.g. `invalid, options, valid`
 
 ## Help Needed
 

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -1,0 +1,241 @@
+- Repo: https://github.com/eslint/eslint
+- Start Date: 2025-07-10
+- RFC PR: (leave this empty, to be filled in later)
+- Authors: ST-DDT
+
+# Rule Tester Assertions Options
+
+## Summary
+
+Add options that control which assertions are required for each `RuleTester` test case.
+
+## Motivation
+
+In most eslint(-plugin)s' rules the error assertions are different from each other.
+Adding options that could be set/shared when configuring the rule tester would ensure a common base level of assertions is met throughout the (plugin's) project.
+The options could be defined on two levels. On `RuleTester`'s `constructor` effectively impacting all tests, or on the test `run` method itself, so only that set is affected.
+
+## Detailed Design
+
+### Variant 1 - Constructor based options
+
+````ts
+new RuleTester(testerConfig: {...}, assertionOptions: {
+    /**
+     * Require message assertion for each invalid test case.
+     * 
+     * @default false
+     */
+    requireMessage: boolean;
+    /**
+     * Require full location assertions for each invalid test case.
+     * 
+     * @default false
+     */
+    requireLocation: boolean;
+} = {});
+````
+
+### Variant 2 - Test method based options
+
+````ts
+ruleTester.run("rule-name", rule, tests, assertionOptions: {
+    /**
+     * Require message assertion for each invalid test case.
+     * 
+     * @default false
+     */
+    requireMessage: boolean;
+    /**
+     * Require full location assertions for each invalid test case.
+     * 
+     * @default false
+     */
+    requireLocation: boolean;
+    /**
+     * Require and expect only the given test scenarios.
+     * This allows omitting certain scenarios from this run with the current options.
+     * 
+     * @default ["valid","invalid"]
+     */
+    requiredScenarios: ReadonlyArray<'valid' | 'invalid'>;
+});
+````
+
+### Shared Logic
+
+If `requireMessage` is set to `true`, the invalid test case cannot consist of an error count assertion only, but must also include a message assertion.
+This can be done either by providing a only message, or by using the `message` property of the error object in the assertion (Same as the current behavior).
+We could enable this property by default, but it would be a breaking change.
+If we add a `requireMessageId` option, it would be mutually exclusive with `requireMessage`, and the invalid test case cannot consist of an error count or message assertion only, but must also include a messageId assertion.
+Alternatively, we could alter the `requireMessage` option to `false | true | "message" | "messageId"` (`true` => `"message"`).
+
+````ts
+ruleTester.run("rule-name", rule, {
+    invalid: [
+        {
+            code: "const a = 1;",
+            errors: 1, // ❌
+        },
+        {
+            code: "const a = 2;",
+            errors: [
+                "Error message here.", // ✅
+            ]
+        },
+        {
+            code: "const a = 3;",
+            errors: [
+                {
+                    message: "Error message here.", // ✅
+                }
+            ]
+        }
+    ]
+}, {
+    requireMessage: true
+});
+````
+
+If `requireLocation` is set to `true`, the invalid test case cannot consist of an error count or errorMessage assertion only, but must also include a full location assertion.
+We could enable this property by default, but it would be a breaking change.
+
+````ts
+ruleTester.run("rule-name", rule, {
+    invalid: [
+        {
+            code: "const a = 1;",
+            errors: 1, // ❌
+        },
+        {
+            code: "const a = 2;",
+            errors: [
+                "Error message here.", // ❌
+            ]
+        },
+        {
+            code: "const a = 3;",
+            errors: [
+                {
+                    line: 1, // ❌
+                    column: 1, 
+                    
+                }
+            ]
+        },
+        {
+            code: "const a = 4;",
+            errors: [
+                {
+                    line: 1, // ✅
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 12,
+                }
+            ]
+        }
+    ]
+}, {
+    requireLocation: true
+});
+````
+
+If `requiredScenarios` is set, the `run` will only require and expect the given scenarios.
+This can only be used for the `run` method, not the constructor, because there should always be at least one valid and one invalid test case.
+The `requiredScenarios` option can be used to omit certain scenarios from the run, e.g. if the user wants to import a set of tests from a different source, that may have other assertion requirements or haven't achieved the quality needed to require the same assertion strictness.
+
+````ts
+ruleTester.run("rule-name", rule, {
+    valid: [...], // ✅
+    invalid: [...],
+}, {
+    // Default is ["valid", "invalid"]
+});
+ruleTester.run("rule-name", rule, {
+    valid: [...], // ❌
+}, {
+    // Default is ["valid", "invalid"]
+});
+ruleTester.run("rule-name", rule, {
+    valid: [...], // ✅
+    invalid: [...],
+}, {
+    requiredScenarios: ["valid", "invalid"]
+});
+ruleTester.run("rule-name", rule, {
+    valid: [...], // ✅
+}, {
+    requiredScenarios: ["valid"]
+});
+ruleTester.run("rule-name", rule, {
+    valid: [...], // ❌
+    invalid: [...],
+}, {
+    requiredScenarios: ["invalid"]
+});
+````
+
+## Documentation
+
+This RFC will be documented in the RuleTester documentation, explaining the new options and how to use them.
+So mainly here: https://eslint.org/docs/latest/integrate/nodejs-api#ruletester
+Additionally, we should write a short blog post to announce for plugin maintainers, to raise awareness of the new options and encourage them to use them in their tests.
+
+## Drawbacks
+
+This proposal adds slightly more complexity to the RuleTester logic, as it needs to handle the new options and enforce the assertions based on them.
+Currently, the RuleTester logic is already deeply nested, so adding more options may make it harder to read and maintain.
+
+Additionally, since we add the options as a second parameter it might interfere with future additions to the parameters.
+This could by eleviated by renaming the parameter from `assertionOptions` to `options` (either from the start or when the need for different type of options arises).
+
+If we enable the `requireMessage` and `requireLocation` options by default, it would be a breaking change for existing tests that do not follow these assertion requirements yet.
+
+## Backwards Compatibility Analysis
+
+This change should not affect existing ESLint users or plugin developers, as it only adds new options to the RuleTester and does not change any existing behavior.
+If we enable the `requireMessage` and `requireLocation` options by default, it would be a breaking change for existing tests that do not follow these assertion requirements yet.
+If we want to enable them by default, we should do so in a major release and communicate the upcoming change to the users early via blog post.
+
+## Alternatives
+
+As an alternative to this proposal, we could add a eslint rule that applies the same assertions, but uses the central eslint config.
+While this would apply the same assertions for all rule testers, it would be a lot more complex to implement and maintain, 
+it requires identifying the RuleTester calls in the codebase and might run into issues if the assertions aren't specified inline but via a variable or transformation.
+
+## Open Questions
+
+1. Is there a need for disabling scenarios like `valid` or `invalid`?
+2. Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files?
+3. Should we enable the `requireMessage` and `requireLocation` options by default? (Breaking change)
+4. Do we add a `requireMessageId` option or should we alter the `requireMessage` option to support both message and messageId assertions?
+5. Should we add a `strict` option that enables all assertion options by default?
+
+## Help Needed
+
+English is not my first language, so I would appreciate help with the wording and grammar of this RFC.
+I'm able to implement this RFC, if we decide to go with options instead of a new rule.
+
+## Frequently Asked Questions
+
+### Why
+
+Because it is easy to miss a missing assertion in RuleTester test cases, especially when many new invalid test cases are added.
+
+## Related Discussions
+
+The idea was initially sparked by this comment: vuejs/eslint-plugin-vue#2773 (comment)
+
+- https://github.com/vuejs/eslint-plugin-vue/pull/2773#discussion_r2176359714
+
+> It might be helpful to include more detailed error information, such as line, column, endLine, and endColumn...
+> [...]
+> Let’s make the new cases more detailed first. 😊
+
+The first steps have been taken in: eslint/eslint#19904 - feat: output full actual location in rule tester if different
+
+- https://github.com/eslint/eslint/pull/19904
+
+This lead to the issue that this RFC is based on: eslint/eslint#19921 - Change Request: Add options to rule-tester requiring certain assertions
+
+- https://github.com/eslint/eslint/issues/19921

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -326,7 +326,7 @@ it requires identifying the RuleTester calls in the codebase and might run into 
 2. Should we use constructor-based options or test method-based options? Do we support both? Or global options so it applies to all test files?
 3. ~~Should we enable the `requireMessage` and `requireLocation` options by default? (Breaking change)~~ No
 4. ~~Do we add a `requireMessageId` option or should we alter the `requireMessage` option to support both message and messageId assertions?~~ Just `requireMessage: boolean | 'message' | 'messageid'`
-5. Should we add a `strict` option that enables all assertion options by default?
+5. ~~Should we add a `strict` option that enables all assertion options by default?~~ No, currently not planned.
 
 ## Help Needed
 

--- a/designs/2025-rule-tester-assertion-options/README.md
+++ b/designs/2025-rule-tester-assertion-options/README.md
@@ -312,6 +312,10 @@ new RuleTester(testerConfig: {...}, assertionOptions: {
 } = {});
 ```
 
+### Options Setter Method
+
+Alternatively add an `setAssertionOptions()` method independently of the constructor and test method.
+
 ### ESLint RuleTester Lint-Rule
 
 As an alternative to this proposal, we could add a eslint rule that applies the same assertions, but uses the central eslint config.


### PR DESCRIPTION
## Summary

Add options that control which assertions are required for each `RuleTester` test case.

## Related Issues

The idea was initially sparked by this comment: [vuejs/eslint-plugin-vue#2773 (comment)](https://github.com/vuejs/eslint-plugin-vue/pull/2773#discussion_r2176359714)

- https://github.com/vuejs/eslint-plugin-vue/pull/2773#discussion_r2176359714

> It might be helpful to include more detailed error information, such as line, column, endLine, and endColumn...
> [...]
> Let’s make the new cases more detailed first. 😊

The first steps have been taken in: eslint/eslint#19904

- https://github.com/eslint/eslint/pull/19904

This lead to the issue that this RFC is based on: eslint/eslint#19921

- https://github.com/eslint/eslint/issues/19921


