### PR TITLE
feat: support GFM alert syntax parsing

### DIFF
--- a/designs/2025-support-gfm-alert-syntax-parsing
+++ b/designs/2025-support-gfm-alert-syntax-parsing
@@ -1,0 +1,104 @@
+- Repo: eslint/markdown
+- Start Date: 2025-08-15
+- RFC PR: TODO
+- Authors: 루밀LuMir(lumirlumir)
+
+# Support GFM Alert syntax parsing
+
+## Summary
+
+<!-- One-paragraph explanation of the feature. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected
+outcome? -->
+
+## Detailed Design
+
+<!--
+   This is the bulk of the RFC.
+
+   Explain the design with enough detail that someone familiar with ESLint
+   can implement it by reading this document. Please get into specifics
+   of your approach, corner cases, and examples of how the change will be
+   used. Be sure to define any new terms in this section.
+-->
+
+## Documentation
+
+<!--
+    How will this RFC be documented? Does it need a formal announcement
+    on the ESLint blog to explain the motivation?
+-->
+
+## Drawbacks
+
+<!--
+    Why should we *not* do this? Consider why adding this into ESLint
+    might not benefit the project or the community. Attempt to think 
+    about any opposing viewpoints that reviewers might bring up. 
+
+    Any change has potential downsides, including increased maintenance
+    burden, incompatibility with other tools, breaking existing user
+    experience, etc. Try to identify as many potential problems with
+    implementing this RFC as possible.
+-->
+
+## Backwards Compatibility Analysis
+
+<!--
+    How does this change affect existing ESLint users? Will any behavior
+    change for them? If so, how are you going to minimize the disruption
+    to existing users?
+-->
+
+## Alternatives
+
+<!--
+    What other designs did you consider? Why did you decide against those?
+
+    This section should also include prior art, such as whether similar
+    projects have already implemented a similar feature.
+-->
+
+## Open Questions
+
+<!--
+    This section is optional, but is suggested for a first draft.
+
+    What parts of this proposal are you unclear about? What do you
+    need to know before you can finalize this RFC?
+
+    List the questions that you'd like reviewers to focus on. When
+    you've received the answers and updated the design to reflect them, 
+    you can remove this section.
+-->
+
+## Help Needed
+
+<!--
+    This section is optional.
+
+    Are you able to implement this RFC on your own? If not, what kind
+    of help would you need from the team?
+-->
+
+## Frequently Asked Questions
+
+<!--
+    This section is optional but suggested.
+
+    Try to anticipate points of clarification that might be needed by
+    the people reviewing this RFC. Include those questions and answers
+    in this section.
+-->
+
+## Related Discussions
+
+<!--
+    This section is optional but suggested.
+
+    If there is an issue, pull request, or other URL that provides useful
+    context for this proposal, please include those links here.
+-->

--- a/designs/2025-support-gfm-alert-syntax-parsing
+++ b/designs/2025-support-gfm-alert-syntax-parsing
@@ -7,7 +7,7 @@
 
 ## Summary
 
-<!-- One-paragraph explanation of the feature. -->
+This RFC proposes adding support for GFM Alert syntax parsing to the `@eslint/markdown` package by implementing custom [`micromark-extension-gfm-alert`](https://github.com/micromark/micromark-extension-gfm?tab=readme-ov-file#when-to-use-this) and [`mdast-util-gfm-alert`](https://github.com/syntax-tree/mdast-util-gfm?tab=readme-ov-file#when-to-use-this) logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
 
 ## Motivation
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -65,6 +65,130 @@ Which is being rendered on GitHub as:
    used. Be sure to define any new terms in this section.
 -->
 
+### Valid Syntax
+
+#### Labels are case-insensitive
+
+<details>
+<summary>Details</summary>
+
+```md
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!note]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!note]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!Note]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!Note]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!NoTe]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NoTe]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!nOtE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!nOtE]
+> Useful information that users should know, even when skimming content.
+
+</details>
+
+### Invalid Syntax
+
+#### `!` prefix should not be surrounded by any spaces (U+0020) or tabs (U+0009).
+
+<details>
+<summary>Details</summary>
+
+```md
+> [ !NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [ !NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [    !NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [    !NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [! NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [! NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!    NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!    NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [ ! NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [ ! NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [    !    NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [    !    NOTE]
+> Useful information that users should know, even when skimming content.
+
+</details>
+
 ## Documentation
 
 <!--
@@ -142,3 +266,10 @@ Which is being rendered on GitHub as:
     If there is an issue, pull request, or other URL that provides useful
     context for this proposal, please include those links here.
 -->
+
+- The reasons why GitHub Alert syntax is not included in Mdast: 
+    - https://github.com/syntax-tree/mdast-util-gfm/issues/2
+    - https://github.com/orgs/syntax-tree/discussions/144
+
+- `rehype-github-alert` library:
+    - https://github.com/rehypejs/rehype-github/tree/main/packages/alert#rehype-github-alert

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -573,7 +573,7 @@ export default defineConfig([
         language: "markdown/gfm",
         languageOptions: {
             frontmatter: "yaml", // Or pass `"toml"` or `"json"` to enable TOML or JSON front matter parsing.
-+           alert: true // Enable GFM alert syntax parsing
++           alert: true // Enable GFM alert syntax parsing (default: `false`)
         },
         rules: {
             "markdown/no-html": "error"

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -204,6 +204,8 @@ The example below shows only `NOTE`, but it applies to all labels such as `TIP`,
 
 #### Upto 4 indented ***space*** is allowed before the ***opening square bracket***
 
+The example below shows only `NOTE`, but it applies to all labels such as `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`.
+
 ```md
 >[!NOTE]
 > Useful information that users should know, even when skimming content.

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -56,21 +56,21 @@ Which is being rendered on GitHub as:
 
 ## Detailed Design
 
-<!--
-   This is the bulk of the RFC.
+### Terms
 
-   Explain the design with enough detail that someone familiar with ESLint
-   can implement it by reading this document. Please get into specifics
-   of your approach, corner cases, and examples of how the change will be
-   used. Be sure to define any new terms in this section.
--->
+Before explaining the design, it's important to define some key terms:
+
+TODO
+
+### Type Interface
+
+```ts
+TODO
+```
 
 ### Valid Syntax
 
 #### Labels are case-insensitive
-
-<details>
-<summary>Details</summary>
 
 ```md
 > [!NOTE]
@@ -126,67 +126,92 @@ Which is being rendered on GitHub as:
 
 #### `!` prefix should not be surrounded by any spaces (U+0020) or tabs (U+0009).
 
+```md
+> [ !NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [ !NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [    !NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [    !NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [! NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [! NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!    NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!    NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [ ! NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [ ! NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [    !    NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [    !    NOTE]
+> Useful information that users should know, even when skimming content.
+
+#### Alert syntax should not be enclosed in HTML opening or closing tags.
+
+```md
+<div>
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+</div>
+```
+
+<div>
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+</div>
+
+---
+
+```md
 <details>
 <summary>Details</summary>
-
-```md
-> [ !NOTE]
+> [!NOTE]
 > Useful information that users should know, even when skimming content.
+</details>
 ```
 
-> [ !NOTE]
+<details>
+<summary>Details</summary>
+> [!NOTE]
 > Useful information that users should know, even when skimming content.
-
----
-
-```md
-> [    !NOTE]
-> Useful information that users should know, even when skimming content.
-```
-
-> [    !NOTE]
-> Useful information that users should know, even when skimming content.
-
----
-
-```md
-> [! NOTE]
-> Useful information that users should know, even when skimming content.
-```
-
-> [! NOTE]
-> Useful information that users should know, even when skimming content.
-
----
-
-```md
-> [!    NOTE]
-> Useful information that users should know, even when skimming content.
-```
-
-> [!    NOTE]
-> Useful information that users should know, even when skimming content.
-
----
-
-```md
-> [ ! NOTE]
-> Useful information that users should know, even when skimming content.
-```
-
-> [ ! NOTE]
-> Useful information that users should know, even when skimming content.
-
----
-
-```md
-> [    !    NOTE]
-> Useful information that users should know, even when skimming content.
-```
-
-> [    !    NOTE]
-> Useful information that users should know, even when skimming content.
-
 </details>
 
 ## Documentation

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -354,6 +354,36 @@ Here are some examples of invalid GFM Alert syntax:
 > [!NOTE] hi
 > Useful information that users should know, even when skimming content.
 
+#### Single-line GFM Alert syntax (without content) isn't working
+
+```md
+> [!NOTE]
+```
+
+> [!NOTE]
+
+---
+
+```md
+> [!NOTE]
+>
+```
+
+> [!NOTE]
+>
+
+#### Nested GFM Alert syntax isn't working
+
+```md
+> > [!NOTE]
+> > Useful information that users should know, even when skimming content.
+```
+
+---
+
+> > [!NOTE]
+> > Useful information that users should know, even when skimming content.
+
 #### GFM Alert syntax should not be enclosed in HTML opening or closing tags
 
 ```md

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -1,6 +1,6 @@
 - Repo: eslint/markdown
 - Start Date: 2025-08-15
-- RFC PR: TODO
+- RFC PR: https://github.com/eslint/rfcs/pull/138
 - Authors: 루밀LuMir(lumirlumir)
 
 # Support GFM Alert syntax parsing

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -201,6 +201,24 @@ TODO
 ---
 
 ```md
+<div>
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+</div>
+```
+
+<div>
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+</div>
+
+---
+
+```md
 <details>
 <summary>Details</summary>
 > [!NOTE]
@@ -212,6 +230,26 @@ TODO
 <summary>Details</summary>
 > [!NOTE]
 > Useful information that users should know, even when skimming content.
+</details>
+
+---
+
+```md
+<details>
+<summary>Details</summary>
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+</details>
+```
+
+<details>
+<summary>Details</summary>
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
 </details>
 
 ## Documentation

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -3,11 +3,11 @@
 - RFC PR: https://github.com/eslint/rfcs/pull/138
 - Authors: 루밀LuMir(lumirlumir)
 
-# Support GFM Alert syntax parsing
+# Support GFM alert syntax parsing
 
 ## Summary
 
-This RFC proposes adding support for GFM Alert syntax parsing to the [`@eslint/markdown`](https://github.com/eslint/markdown) package by implementing `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` custom plugin logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
+This RFC proposes adding support for GFM alert syntax parsing to the [`@eslint/markdown`](https://github.com/eslint/markdown) package by implementing `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` custom plugin logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
 
 ## Motivation
 
@@ -17,9 +17,9 @@ Currently, GitHub supports a special syntax for alerts that isn't mentioned in t
 
 Inconsistencies between GitHub's GFM alert syntax and existing Markdown parsers can cause false positives and false negatives in some cases, especially when writing rules that detect error-prone syntax and when the syntax overlaps with GitHub's alert syntax.
 
-This RFC aims to address that gap by introducing the necessary parsing logic and formal specification for GFM Alert syntax.
+This RFC aims to address that gap by introducing the necessary parsing logic and formal specification for GFM alert syntax.
 
-GFM Alert syntax is a way to create attention-grabbing blocks in Markdown content. It uses a specific syntax to denote different types of alerts, such as notes, tips, warnings, and more. The basic structure of a GFM Alert is as follows:
+GFM alert syntax is a way to create attention-grabbing blocks in Markdown content. It uses a specific syntax to denote different types of alerts, such as notes, tips, warnings, and more. The basic structure of a GFM alert is as follows:
 
 ```md
 > [!NOTE]
@@ -73,7 +73,7 @@ Before explaining the design, it's important to define some key terms:
 
 ### Type Interface
 
-Since GFM Alert syntax is part of blockquote syntax from Markdown, `Alert` interface extends [`Blockquote`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#blockquote) node type of Mdast.
+Since GFM alert syntax is part of blockquote syntax from Markdown, `Alert` interface extends [`Blockquote`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#blockquote) node type of Mdast.
 
 ```ts
 import type { Blockquote } from "mdast";
@@ -98,7 +98,7 @@ interface Alert extends Blockquote {
 
 ### Valid Syntax
 
-Here are some examples of valid GFM Alert syntax:
+Here are some examples of valid GFM alert syntax:
 
 #### `NOTE`, `TIP`, `IMPORTANT`, `WARNING` and `CAUTION` are valid ***label***s
 
@@ -292,7 +292,7 @@ Here are some examples of valid GFM Alert syntax:
 
 ### Invalid Syntax
 
-Here are some examples of invalid GFM Alert syntax:
+Here are some examples of invalid GFM alert syntax:
 
 #### ***exclamation mark*** should not be surrounded by any ***space***s or ***tab***s
 
@@ -414,7 +414,7 @@ Here are some examples of invalid GFM Alert syntax:
 > [!NOTE] hi
 > Useful information that users should know, even when skimming content.
 
-#### GFM Alert syntax without content isn't working
+#### GFM alert syntax without content isn't working
 
 ```md
 > [!NOTE]
@@ -432,7 +432,7 @@ Here are some examples of invalid GFM Alert syntax:
 > [!NOTE]
 >
 
-#### Multi-line GFM Alert syntax isn't working
+#### Multi-line GFM alert syntax isn't working
 
 ```md
 > [
@@ -456,7 +456,7 @@ Here are some examples of invalid GFM Alert syntax:
 > ]
 > Useful information that users should know, even when skimming content.
 
-#### Nested GFM Alert syntax isn't working
+#### Nested GFM alert syntax isn't working
 
 ```md
 > > [!NOTE]
@@ -476,7 +476,7 @@ Here are some examples of invalid GFM Alert syntax:
 - > [!NOTE]
 - > Useful information that users should know, even when skimming content.
 
-#### GFM Alert syntax should not be enclosed in HTML opening or closing tags
+#### GFM alert syntax should not be enclosed in HTML opening or closing tags
 
 ```md
 <div>
@@ -546,7 +546,7 @@ Here are some examples of invalid GFM Alert syntax:
 
 ## Documentation
 
-We need to update the [`README.md`](https://github.com/eslint/markdown?tab=readme-ov-file#eslint-markdown-language-plugin) for `@eslint/markdown` to include details about the new GFM Alert syntax parsing feature. In particular, we should document the new `alert` option under the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) section.  
+We need to update the [`README.md`](https://github.com/eslint/markdown?tab=readme-ov-file#eslint-markdown-language-plugin) for `@eslint/markdown` to include details about the new GFM alert syntax parsing feature. In particular, we should document the new `alert` option under the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) section.  
 
 ## Drawbacks
 
@@ -573,7 +573,7 @@ export default defineConfig([
         language: "markdown/gfm",
         languageOptions: {
             frontmatter: "yaml", // Or pass `"toml"` or `"json"` to enable TOML or JSON front matter parsing.
-+           alert: true // Enable GFM Alert syntax parsing
++           alert: true // Enable GFM alert syntax parsing
         },
         rules: {
             "markdown/no-html": "error"
@@ -588,7 +588,7 @@ I cannot find any significant alternatives to this proposal. but I am open to su
 
 ### Pre-existing Implementations
 
-There are existing implementations of GFM Alert syntax parsing in other Markdown and HTML parsers:
+There are existing implementations of GFM alert syntax parsing in other Markdown and HTML parsers:
 
 - `rehype-github-alert`: https://github.com/rehypejs/rehype-github/tree/main/packages/alert#rehype-github-alert
 - `markdown-it-github-alert`: https://github.com/antfu/markdown-it-github-alerts
@@ -609,7 +609,7 @@ N/A
 
 ## Related Discussions
 
-### The reasons why GitHub Alert syntax is not included in Mdast
+### The reasons why GitHub alert syntax is not included in Mdast
 
 - https://github.com/syntax-tree/mdast-util-gfm/issues/2
 - https://github.com/orgs/syntax-tree/discussions/144

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -7,12 +7,52 @@
 
 ## Summary
 
-This RFC proposes adding support for GFM Alert syntax parsing to the `@eslint/markdown` package by implementing custom [`micromark-extension-gfm-alert`](https://github.com/micromark/micromark-extension-gfm?tab=readme-ov-file#when-to-use-this) and [`mdast-util-gfm-alert`](https://github.com/syntax-tree/mdast-util-gfm?tab=readme-ov-file#when-to-use-this) logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
+This RFC proposes adding support for GFM Alert syntax parsing to the `@eslint/markdown` package by implementing custom `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
 
 ## Motivation
 
-<!-- Why are we doing this? What use cases does it support? What is the expected
-outcome? -->
+The motivation for this RFC comes from [eslint/markdown#294](https://github.com/eslint/markdown/issues/294) and [eslint/markdown#449](https://github.com/eslint/markdown/issues/449).
+
+Currently, GitHub supports a special syntax for alerts that isn't mentioned in the [GitHub Flavored Markdown spec](https://github.github.com/gfm/) and isn't parsed by the existing [`micromark-extension-gfm`](https://github.com/micromark/micromark-extension-gfm?tab=readme-ov-file#when-to-use-this) or [`mdast-util-gfm`](https://github.com/syntax-tree/mdast-util-gfm?tab=readme-ov-file#when-to-use-this) packages, which are used internally by `@eslint/markdown` to parse Markdown content and create AST nodes.
+
+This RFC aims to address that gap by introducing the necessary parsing logic and formal specification for GFM Alert syntax.
+
+GFM Alert syntax is a way to create attention-grabbing blocks in Markdown content. It uses a specific syntax to denote different types of alerts, such as notes, tips, warnings, and more. The basic structure of a GFM Alert is as follows:
+
+```md
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+```
+
+Which is being rendered on GitHub as:
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
 
 ## Detailed Design
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -120,7 +120,55 @@ TODO
 > [!nOtE]
 > Useful information that users should know, even when skimming content.
 
-</details>
+#### Upto 4 indented space (U+0009) is allowed before the `[` bracket.
+
+```md
+>[!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+>[!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+>  [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+>  [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+>   [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+>   [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+>    [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+>    [!NOTE]
+> Useful information that users should know, even when skimming content.
 
 ### Invalid Syntax
 
@@ -182,6 +230,26 @@ TODO
 ```
 
 > [    !    NOTE]
+> Useful information that users should know, even when skimming content.
+
+#### Labels should not end with spaces (U+0020) or tabs (U+0009).
+
+```md
+> [!NOTE ]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE ]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!NOTE    ]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE    ]
 > Useful information that users should know, even when skimming content.
 
 #### Alert syntax should not be enclosed in HTML opening or closing tags.

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -11,7 +11,7 @@ This RFC proposes adding support for GFM alert syntax parsing to the [`@eslint/m
 
 ## Motivation
 
-The motivation for this RFC comes from [eslint/markdown#294](https://github.com/eslint/markdown/issues/294) and [eslint/markdown#449](https://github.com/eslint/markdown/issues/449).
+The motivation for this RFC comes from [eslint/markdown#294](https://github.com/eslint/markdown/issues/294).
 
 Currently, GitHub supports a special syntax for alerts that isn't mentioned in the [GitHub Flavored Markdown spec](https://github.github.com/gfm/) and isn't parsed by the existing [`micromark-extension-gfm`](https://github.com/micromark/micromark-extension-gfm?tab=readme-ov-file#when-to-use-this) and [`mdast-util-gfm`](https://github.com/syntax-tree/mdast-util-gfm?tab=readme-ov-file#when-to-use-this) packages, which are used internally by `@eslint/markdown` to parse Markdown content and create AST nodes.
 
@@ -150,7 +150,9 @@ Here are some examples of valid GFM alert syntax:
 > [!CAUTION]
 > Advises about risks or negative outcomes of certain actions.
 
-#### ***Label***s are case-insensitive
+#### All of the following are case-insensitive ***label***s: `NOTE`, `TIP`, `IMPORTANT`, `WARNING` and `CAUTION`
+
+The example below shows only `NOTE`, but it applies to all labels such as `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`.
 
 ```md
 > [!NOTE]

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -272,6 +272,8 @@ TODO
     implementing this RFC as possible.
 -->
 
+1. It's not an official GitHub Flavored Markdown specification.
+
 ## Backwards Compatibility Analysis
 
 <!--
@@ -279,6 +281,33 @@ TODO
     change for them? If so, how are you going to minimize the disruption
     to existing users?
 -->
+
+Adding the `alert` option to the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) field will not affect existing functionality in `@eslint/markdown@7`.
+
+This option can be enabled by default when `@eslint/markdown@8` is released.
+
+```diff
+// eslint.config.js
+import { defineConfig } from "eslint/config";
+import markdown from "@eslint/markdown";
+
+export default defineConfig([
+    {
+        files: ["**/*.md"],
+        plugins: {
+            markdown
+        },
+        language: "markdown/gfm",
+        languageOptions: {
+            frontmatter: "yaml", // Or pass `"toml"` or `"json"` to enable TOML or JSON front matter parsing.
++           alert: true // Enable GFM Alert syntax parsing
+        },
+        rules: {
+            "markdown/no-html": "error"
+        }
+    }
+]);
+```
 
 ## Alternatives
 
@@ -334,5 +363,11 @@ TODO
     - https://github.com/syntax-tree/mdast-util-gfm/issues/2
     - https://github.com/orgs/syntax-tree/discussions/144
 
-- `rehype-github-alert` library:
+- `micromark-util` library reference:
+    - TODO
+
+- `mdast-util` library reference:
+    - `mdast-util-math`: https://github.com/syntax-tree/mdast-util-math
+
+- `rehype-github-alert` library reference:
     - https://github.com/rehypejs/rehype-github/tree/main/packages/alert#rehype-github-alert

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -374,6 +374,26 @@ Here are some examples of invalid GFM Alert syntax:
 > [!NOTE    ]
 > Useful information that users should know, even when skimming content.
 
+#### Only ***space***s and ***tab***s are allowed before the ***opening square bracket***
+
+```md
+> hi[!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> hi[!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> hi [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> hi [!NOTE]
+> Useful information that users should know, even when skimming content.
+
 #### Only ***space***s, ***tab***s, and ***line ending***s are allowed after the ***closing square bracket***
 
 ```md

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -77,7 +77,7 @@ This suggestion requires adding an option to `languageOptions` in the `@eslint/m
 
 `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` complement each other and are intended to be used together to provide full support for the GFM alert syntax.
 
-To enable parsing of GFM alert syntax, set the `alert` option to `true`; set it to `false` to disable it. Only the boolean values `true` and `false` are accepted.
+To enable parsing of GFM alert syntax, set the `languageOptions.alert` option to `true`; set it to `false` to disable it. Only the boolean values `true` and `false` are accepted.
 
 Adding the `alert` option to the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) and set it to `false` by default will not affect existing functionality in `@eslint/markdown@7` (version 7.x.x).
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -593,6 +593,8 @@ There are existing implementations of GFM alert syntax parsing in other Markdown
 - `rehype-github-alert`: https://github.com/rehypejs/rehype-github/tree/main/packages/alert#rehype-github-alert
 - `markdown-it-github-alert`: https://github.com/antfu/markdown-it-github-alerts
 
+However, these plugins cannot be used in the `eslint/markdown` package, because `rehype-github-alert` is a plugin for `rehype` (which uses [HAST](https://github.com/syntax-tree/hast#readme) AST) and `markdown-it-github-alert` is a plugin for `markdown-it` (which uses its own Markdown AST), while `eslint/markdown` parses Markdown using `micromark` and `mdast` (which uses [MDAST](https://github.com/syntax-tree/mdast#readme) AST).
+
 ## Open Questions
 
 1. Will the `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` plugins be published as separate packages?

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -597,7 +597,8 @@ However, these plugins cannot be used in the `eslint/markdown` package, because 
 
 ## Open Questions
 
-1. Will the `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` plugins be published as separate packages?
+- Question 1. Will the `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` plugins be published as separate packages?
+- Answer 1. According to the [comment](https://github.com/eslint/rfcs/pull/138#discussion_r2288501879), it is not preferred to have additional packages to maintain for this.
 
 ## Help Needed
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -71,6 +71,53 @@ Before explaining the design, it's important to define some key terms:
 - ***line ending***: According to the [CommonMark spec](https://spec.commonmark.org/0.31.2/#line-ending), A line ending is a line feed (U+000A), a carriage return (U+000D) not followed by a line feed, or a carriage return and a following line feed.
 - ***label***: The text that appears inside the ***opening square bracket*** and ***closing square bracket*** and is prefixed by an ***exclamation mark***. It determines the style and semantics of the alert.
 
+### GFM alert syntax in plugins and configs
+
+This suggestion requires adding an option to `languageOptions` in the `@eslint/markdown` to enable parsing of GFM alert syntax.
+
+`micromark-extension-gfm-alert` and `mdast-util-gfm-alert` complement each other and are intended to be used together to provide full support for the GFM alert syntax.
+
+To enable parsing of GFM alert syntax, set the `alert` option to `true`; set it to `false` to disable it. Only the boolean values `true` and `false` are accepted.
+
+Adding the `alert` option to the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) and set it to `false` by default will not affect existing functionality in `@eslint/markdown@7` (version 7.x.x).
+
+If desired, this option could be enabled by default in `@eslint/markdown@8` (version 8.x.x).
+
+```diff
+// eslint.config.js
+import { defineConfig } from "eslint/config";
+import markdown from "@eslint/markdown";
+
+export default defineConfig([
+    {
+        files: ["**/*.md"],
+        plugins: {
+            markdown
+        },
+        language: "markdown/gfm",
+        languageOptions: {
+            frontmatter: "yaml", // Or pass `"toml"` or `"json"` to enable TOML or JSON front matter parsing.
++           alert: true // Enable GFM alert syntax parsing (default: `false`)
+        },
+        rules: {
+            "markdown/no-html": "error"
+        }
+    }
+]);
+```
+
+### Where would the `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` packages live?
+
+#### `micromark-extension-gfm-alert`
+
+- `micromark-extension-gfm-alert` source code logic would be implemented in the `src/extensions/micromark-extension-gfm-alert.js` file.
+- `micromark-extension-gfm-alert` test files would be implemented in the `tests/extensions/micromark-extension-gfm-alert.test.js` file.
+
+#### `mdast-util-gfm-alert`
+
+- `mdast-util-gfm-alert` source code logic would be implemented in the `src/extensions/mdast-util-gfm-alert.js` file.
+- `mdast-util-gfm-alert` test files would be implemented in the `tests/extensions/mdast-util-gfm-alert.test.js` file.
+
 ### Type Interface
 
 Since GFM alert syntax is part of blockquote syntax from Markdown, `Alert` interface extends [`Blockquote`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#blockquote) node type of Mdast.
@@ -559,32 +606,9 @@ We need to update the [`README.md`](https://github.com/eslint/markdown?tab=readm
 
 ## Backwards Compatibility Analysis
 
-Adding the `alert` option to the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) and set it to `false` by default will not affect existing functionality in `@eslint/markdown@7`.
+This proposal is fully backward-compatible, as it only adds new options and does not remove or modify existing features.
 
-If desired, this option could be enabled by default in `@eslint/markdown@8`.
-
-```diff
-// eslint.config.js
-import { defineConfig } from "eslint/config";
-import markdown from "@eslint/markdown";
-
-export default defineConfig([
-    {
-        files: ["**/*.md"],
-        plugins: {
-            markdown
-        },
-        language: "markdown/gfm",
-        languageOptions: {
-            frontmatter: "yaml", // Or pass `"toml"` or `"json"` to enable TOML or JSON front matter parsing.
-+           alert: true // Enable GFM alert syntax parsing (default: `false`)
-        },
-        rules: {
-            "markdown/no-html": "error"
-        }
-    }
-]);
-```
+No changes are required from end users.
 
 ## Alternatives
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -424,10 +424,7 @@ Here are some examples of invalid GFM Alert syntax:
 
 ## Documentation
 
-<!--
-    How will this RFC be documented? Does it need a formal announcement
-    on the ESLint blog to explain the motivation?
--->
+We need to update the [`README.md`](https://github.com/eslint/markdown?tab=readme-ov-file#eslint-markdown-language-plugin) for `@eslint/markdown` to include details about the new GFM Alert syntax parsing feature. In particular, we should document the new `alert` option under the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) section.  
 
 ## Drawbacks
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -250,6 +250,46 @@ Here are some examples of valid GFM Alert syntax:
 >    [!NOTE]
 > Useful information that users should know, even when skimming content.
 
+#### Upto 3 indented ***space*** is allowed before the ***closing angle bracket***
+
+```md
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+ > [!NOTE]
+ > Useful information that users should know, even when skimming content.
+```
+
+ > [!NOTE]
+ > Useful information that users should know, even when skimming content.
+
+---
+
+```md
+  > [!NOTE]
+  > Useful information that users should know, even when skimming content.
+```
+
+  > [!NOTE]
+  > Useful information that users should know, even when skimming content.
+
+---
+
+```md
+   > [!NOTE]
+   > Useful information that users should know, even when skimming content.
+```
+
+   > [!NOTE]
+   > Useful information that users should know, even when skimming content.
+
 ### Invalid Syntax
 
 Here are some examples of invalid GFM Alert syntax:

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -64,8 +64,31 @@ TODO
 
 ### Type Interface
 
+`Alert` interface extends [`Blockquote`](https://github.com/syntax-tree/mdast?tab=readme-ov-file#blockquote) node type of Mdast.
+
 ```ts
-TODO
+import type { Blockquote } from "mdast";
+
+interface Alert extends Blockquote {
+    /**
+     * Node type of mdast GFM alert.
+     */
+    type: "alert";
+    /**
+     * The label of the alert. It determines the style and semantics of the alert.
+     * 
+     * Its value should remain in its parsed form and should not be normalized.
+     *
+     * You can normalize its value by converting it to lowercase.
+     * The normalized value should be one of the following:
+     * - `"note"`
+     * - `"tip"`
+     * - `"important"`
+     * - `"warning"`
+     * - `"caution"`
+     */
+    label: string;
+}
 ```
 
 ### Valid Syntax

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -555,7 +555,7 @@ We need to update the [`README.md`](https://github.com/eslint/markdown?tab=readm
 
 ## Backwards Compatibility Analysis
 
-Adding the `alert` option to the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) field will not affect existing functionality in `@eslint/markdown@7`.
+Adding the `alert` option to the [Language Options](https://github.com/eslint/markdown?tab=readme-ov-file#language-options) and set it to `false` by default will not affect existing functionality in `@eslint/markdown@7`.
 
 If desired, this option could be enabled by default in `@eslint/markdown@8`.
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -100,7 +100,7 @@ interface Alert extends Blockquote {
 
 Here are some examples of valid GFM alert syntax:
 
-#### `NOTE`, `TIP`, `IMPORTANT`, `WARNING` and `CAUTION` are valid ***label***s
+#### All of the following are valid ***label***s: `NOTE`, `TIP`, `IMPORTANT`, `WARNING` and `CAUTION`
 
 ```md
 > [!NOTE]

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-This RFC proposes adding support for GFM Alert syntax parsing to the `@eslint/markdown` package by implementing `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` custom plugin logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
+This RFC proposes adding support for GFM Alert syntax parsing to the [`@eslint/markdown`](https://github.com/eslint/markdown) package by implementing `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` custom plugin logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).
 
 ## Motivation
 
@@ -15,7 +15,7 @@ The motivation for this RFC comes from [eslint/markdown#294](https://github.com/
 
 Currently, GitHub supports a special syntax for alerts that isn't mentioned in the [GitHub Flavored Markdown spec](https://github.github.com/gfm/) and isn't parsed by the existing [`micromark-extension-gfm`](https://github.com/micromark/micromark-extension-gfm?tab=readme-ov-file#when-to-use-this) and [`mdast-util-gfm`](https://github.com/syntax-tree/mdast-util-gfm?tab=readme-ov-file#when-to-use-this) packages, which are used internally by `@eslint/markdown` to parse Markdown content and create AST nodes.
 
-Inconsistencies between GitHub's GFM alert syntax and existing Markdown parsers cause false positives and false negatives in some situations, especially when writing rules whose syntax overlaps with GitHub's alert syntax.
+Inconsistencies between GitHub's GFM alert syntax and existing Markdown parsers can cause false positives and false negatives in some cases, especially when writing rules that detect error-prone syntax and when the syntax overlaps with GitHub's alert syntax.
 
 This RFC aims to address that gap by introducing the necessary parsing logic and formal specification for GFM Alert syntax.
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -414,7 +414,7 @@ Here are some examples of invalid GFM Alert syntax:
 > [!NOTE] hi
 > Useful information that users should know, even when skimming content.
 
-#### Single-line GFM Alert syntax (without content) isn't working
+#### GFM Alert syntax without content isn't working
 
 ```md
 > [!NOTE]
@@ -431,6 +431,30 @@ Here are some examples of invalid GFM Alert syntax:
 
 > [!NOTE]
 >
+
+#### Multi-line GFM Alert syntax isn't working
+
+```md
+> [
+> !NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [
+> !NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!NOTE
+> ]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE
+> ]
+> Useful information that users should know, even when skimming content.
 
 #### Nested GFM Alert syntax isn't working
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -439,10 +439,18 @@ Here are some examples of invalid GFM Alert syntax:
 > > Useful information that users should know, even when skimming content.
 ```
 
----
-
 > > [!NOTE]
 > > Useful information that users should know, even when skimming content.
+
+---
+
+```md
+- > [!NOTE]
+- > Useful information that users should know, even when skimming content.
+```
+
+- > [!NOTE]
+- > Useful information that users should know, even when skimming content.
 
 #### GFM Alert syntax should not be enclosed in HTML opening or closing tags
 

--- a/designs/2025-support-gfm-alert-syntax-parsing/README.md
+++ b/designs/2025-support-gfm-alert-syntax-parsing/README.md
@@ -70,6 +70,56 @@ TODO
 
 ### Valid Syntax
 
+#### `NOTE`, `TIP`, `IMPORTANT`, `WARNING` and `CAUTION` are valid labels
+
+```md
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+```
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+---
+
+```md
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+```
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+---
+
+```md
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+```
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+---
+
+```md
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+```
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
 #### Labels are case-insensitive
 
 ```md
@@ -120,7 +170,7 @@ TODO
 > [!nOtE]
 > Useful information that users should know, even when skimming content.
 
-#### Upto 4 indented space (U+0009) is allowed before the `[` bracket.
+#### Upto 4 indented space (U+0009) is allowed before the `[` bracket
 
 ```md
 >[!NOTE]
@@ -172,7 +222,7 @@ TODO
 
 ### Invalid Syntax
 
-#### `!` prefix should not be surrounded by any spaces (U+0020) or tabs (U+0009).
+#### `!` prefix should not be surrounded by any spaces (U+0020) or tabs (U+0009)
 
 ```md
 > [ !NOTE]
@@ -232,7 +282,7 @@ TODO
 > [    !    NOTE]
 > Useful information that users should know, even when skimming content.
 
-#### Labels should not end with spaces (U+0020) or tabs (U+0009).
+#### Labels should not end with spaces (U+0020) or tabs (U+0009)
 
 ```md
 > [!NOTE ]
@@ -252,7 +302,27 @@ TODO
 > [!NOTE    ]
 > Useful information that users should know, even when skimming content.
 
-#### Alert syntax should not be enclosed in HTML opening or closing tags.
+#### Only spaces (U+0020), tabs (U+0009), and [line ending](https://spec.commonmark.org/0.31.2/#line-ending) are allowed after the `]` bracket
+
+```md
+> [!NOTE]hi
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE]hi
+> Useful information that users should know, even when skimming content.
+
+---
+
+```md
+> [!NOTE] hi
+> Useful information that users should know, even when skimming content.
+```
+
+> [!NOTE] hi
+> Useful information that users should know, even when skimming content.
+
+#### Alert syntax should not be enclosed in HTML opening or closing tags
 
 ```md
 <div>


### PR DESCRIPTION
## Summary

This RFC proposes adding support for GFM alert syntax parsing to the `@eslint/markdown` package by implementing `micromark-extension-gfm-alert` and `mdast-util-gfm-alert` custom plugin logic, and also includes the formal specification based on the [CommonMark spec](https://spec.commonmark.org/) and the [GitHub Flavored Markdown spec](https://github.github.com/gfm/).

## Related Issues

<!-- optional: include links to relevant discussions here -->

Refs: https://github.com/eslint/markdown/issues/294
