### PR TITLE
feat: Add getPossibleTypesForSelectorClass to Language interface

### DIFF
--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -1,6 +1,6 @@
 - Repo: eslint/eslint
 - Start Date: 2026-05-23
-- RFC PR: (fill in after PR is created)
+- RFC PR: https://github.com/eslint/rfcs/pull/148
 - Authors: [Kuldeep2822k](https://github.com/Kuldeep2822k)
 
 # Add `getPossibleTypesForSelectorClass` to the Language Interface

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -1,7 +1,7 @@
 - Repo: eslint/eslint
 - Start Date: 2026-05-23
 - RFC PR: https://github.com/eslint/rfcs/pull/148
-- Authors: [Kuldeep2822k](https://github.com/Kuldeep2822k)
+- Authors: Kuldeep2822k
 
 # Add `getPossibleTypesForSelectorClass` to the Language Interface
 

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -252,24 +252,21 @@ This change is **fully backwards compatible**:
 
 ## Alternatives
 
-### 1. Do Nothing (Status Quo)
-
-Leave the hardcoded JS logic in `esquery.js` with the `TODO` comment. This is the simplest approach, and the maintainer has acknowledged the current state is acceptable. However, it leaves a known architectural debt and prevents other languages from benefiting from the same optimization.
-
-### 2. Move Logic Without a Language Interface Method
+### 1. Move Logic Without a Language Interface Method
 
 Move the hardcoded logic into a helper function that checks the language identity (e.g., `if (language === jsLanguage)`) rather than adding a generic interface method. This removes the hardcoding from `esquery.js` but doesn't provide a generic solution for other languages and still couples the core to the JS language.
 
-### 3. Use `matchesSelectorClass()` for Static Analysis
+### 2. Use `matchesSelectorClass()` for Static Analysis
 
 Instead of adding a new method, try to infer possible types by calling `matchesSelectorClass()` against a set of known node types. This is impractical because:
 - The set of possible node types is unbounded (any language can define any node types).
 - It would require instantiating dummy nodes for every possible type.
 - It conflates runtime matching with static analysis.
 
-### 4. Extend `matchesSelectorClass()` to Return Type Information
+### 3. Extend `matchesSelectorClass()` to Return Type Information
 
 Instead of a separate method, modify `matchesSelectorClass()` to optionally return type information. This was rejected because it changes the semantics of an existing method and makes the return type complex (boolean vs. type array).
+
 
 ## Open Questions
 

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -3,11 +3,11 @@
 - RFC PR: https://github.com/eslint/rfcs/pull/148
 - Authors: Kuldeep2822k
 
-# Add `getPossibleTypesForSelectorClass` to the Language Interface
+# Add `getSelectorClassNodeTypes` to the Language Interface
 
 ## Summary
 
-Add an optional `getPossibleTypesForSelectorClass(className)` method to the `Language` interface that allows languages to declare which AST node types could match a given pseudo-class selector (e.g., `:function`). This removes hardcoded JavaScript-specific logic from the core selector analysis in `lib/linter/esquery.js` and enables any language plugin to provide the same optimization.
+Add an optional `getSelectorClassNodeTypes(className)` method to the Language interface that allows languages to declare which AST node types could match a given pseudo-class selector (e.g., `:function`). This removes hardcoded JavaScript-specific logic from the core selector analysis in `lib/linter/esquery.js` and enables any language plugin to participate in selector static analysis.
 
 ## Motivation
 
@@ -33,22 +33,22 @@ This presents several problems:
 
 1. **Language-agnostic roadmap conflict.** The Language interface was designed ([RFC #99](https://github.com/eslint/rfcs/pull/99)) to make ESLint language-agnostic. Having JS-specific logic in the core selector engine contradicts this goal.
 
-2. **Missing optimization for other languages.** The Language interface already provides `matchesSelectorClass()` for _runtime_ matching of nodes against pseudo-classes. However, there is no companion method for _static analysis_ — determining upfront which node types a pseudo-class could possibly match. Languages like CSS, Markdown, JSON, HTML, and YAML that implement custom pseudo-classes cannot benefit from this traversal optimization.
+2. **Incomplete selector-class extension API.** The current Language interface allows plugins to define runtime pseudo-class behavior through `matchesSelectorClass()`, but provides no mechanism for participating in selector static analysis. This means custom language plugins cannot integrate fully with ESLint's traversal optimization pipeline even when their pseudo-classes map to a finite set of node types. Without a static analysis companion, plugin authors would need to request core changes for every optimizable pseudo-class, and selector semantics would not be fully owned by the language implementation — contradicting the language-agnostic architecture.
 
 3. **Maintenance concern.** The existing `TODO` comment explicitly acknowledges this code doesn't belong in the core. As more languages are added, having JS-specific logic in the core linter becomes increasingly confusing for contributors.
 
-The Language interface already has a precedent for this pattern: `matchesSelectorClass()` handles runtime matching, and the proposed `getPossibleTypesForSelectorClass()` would handle static analysis. Together, they provide a complete, language-agnostic pseudo-class system.
+Selector analysis depends on selector semantics, and selector semantics are already delegated to language implementations through `matchesSelectorClass()`. Static analysis therefore belongs to the same abstraction boundary. The proposed `getSelectorClassNodeTypes()` completes this symmetry, providing a full, language-agnostic pseudo-class system where both runtime matching and static analysis are owned by the language implementation.
 
 ## Detailed Design
 
 This proposal consists of the following changes:
 
-1. Add an optional `getPossibleTypesForSelectorClass()` method to the `Language` interface (in `@eslint/core`).
+1. Add an optional `getSelectorClassNodeTypes()` method to the `Language` interface (in `@eslint/core`).
 2. Move the JS-specific `:function` mapping into `lib/languages/js/index.js`.
 3. Update `lib/linter/esquery.js` to call the language method instead of using hardcoded logic.
 4. Make the selector cache language-aware.
 
-### The `getPossibleTypesForSelectorClass()` Method
+### The `getSelectorClassNodeTypes()` Method
 
 A new optional method is added to the `Language` interface:
 
@@ -66,24 +66,28 @@ interface Language {
      * @returns An array of node type strings that could match, or
      *          `null` if all node types could potentially match.
      */
-    getPossibleTypesForSelectorClass?(className: string): string[] | null;
+    getSelectorClassNodeTypes?(className: string): string[] | null;
 }
 ```
 
 **Return value semantics:**
 
-- **`string[]`** — Only nodes of these types could match the pseudo-class. The traverser will only check these node types, skipping all others.
+- **`string[]`** — Only nodes of these types could match the pseudo-class. The traverser will only invoke selector matching for these node types, skipping all others.
 - **`null`** — Any node type could match. The traverser must check every node (this is the safe fallback).
 
-**If a language does not implement this method**, the core falls back to returning `null` for all class selectors, which is functionally equivalent to the current behavior for all pseudo-classes _except_ `:function` in JS. This means no existing language is negatively affected.
+**If a language does not implement this method**, the core falls back to returning `null` for all class selectors, which is functionally equivalent to the current behavior for all pseudo-classes _except_ `:function` in JS. Existing language implementations remain unaffected.
+
+**Semantic invariant:** For correctness, the set of node types returned by `getSelectorClassNodeTypes()` MUST be a superset of the types that actually match through `matchesSelectorClass()`. Returning extra types is allowed and only reduces optimization quality — the traverser checks more nodes than necessary, but never misses a match.
+
+**Why `null` instead of `undefined`:** `null` is used intentionally to distinguish "all node types may match" (an explicit statement about the pseudo-class) from "method not implemented" (which is `undefined` via optional chaining). This prevents collapsing semantics between an explicitly non-optimizable pseudo-class and a missing method.
 
 ### JavaScript Language Implementation
 
 The JS language object in [`lib/languages/js/index.js`](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js) would implement this method alongside the existing `matchesSelectorClass()`:
 
 ```js
-getPossibleTypesForSelectorClass(className) {
-    if (className === "function") {
+getSelectorClassNodeTypes(className) {
+    if (className.toLowerCase() === "function") {
         return [
             "FunctionDeclaration",
             "FunctionExpression",
@@ -94,11 +98,26 @@ getPossibleTypesForSelectorClass(className) {
 }
 ```
 
-This is a direct extraction of the logic currently hardcoded in `esquery.js` (line 210: `if (selector.name === "function")`). Note that the existing hardcoded check uses a case-sensitive comparison (`===`), and so does this implementation to maintain the same behavior. The `className` parameter receives the raw `selector.name` value from the esquery parsed AST, which preserves the casing as written in the selector string (e.g., `:function` → `"function"`).
+This is a direct extraction of the logic currently hardcoded in `esquery.js` (line 210: `if (selector.name === "function")`). Note that the existing hardcoded check in `esquery.js` uses a case-sensitive comparison (`===`), but the runtime `matchesSelectorClass()` (line 191) uses `className.toLowerCase()` for case-insensitive matching. The proposed implementation uses `.toLowerCase()` to remain consistent with `matchesSelectorClass()`, since esquery's parser preserves the raw casing of `selector.name` (e.g., `:Function` → `"Function"`). The case-sensitive hardcoded check in `esquery.js` only works because selectors are conventionally lowercase; `getSelectorClassNodeTypes()` should handle edge cases consistently with the runtime method.
 
-The existing `matchesSelectorClass()` in the JS language already handles runtime matching for classes like `statement`, `declaration`, `pattern`, `expression`, and `function` (see [lines 163-229](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js#L163-L229)). This new method provides the static type analysis companion.
+The existing `matchesSelectorClass()` in the JS language already handles runtime matching for classes like `statement`, `declaration`, `pattern`, `expression`, and `function` (see [lines 163-229](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js#L163-L229)). `getSelectorClassNodeTypes()` provides the static type analysis companion.
 
-Note: The other pseudo-classes (`statement`, `declaration`, `pattern`, `expression`) return `null` from the static analysis (meaning "any type could match") because they match based on suffix patterns (e.g., any type ending in `"Statement"`) or complex conditions involving ancestry. We cannot statically enumerate all possible node types for these classes. Only `:function`, which matches a fixed set of three specific types, benefits from this optimization.
+Note: The other pseudo-classes (`statement`, `declaration`, `pattern`, `expression`) return `null` from the static analysis (meaning "any type could match") because they match based on suffix patterns (e.g., any type ending in `"Statement"`) or complex conditions involving ancestry. These pseudo-classes are defined by structural or naming conventions rather than a fixed closed set of node types, making enumeration language-specific and potentially brittle. Only `:function`, which maps to a fixed closed set of node types, benefits from this optimization.
+
+### Example: CSS Language Plugin
+
+To illustrate the extensibility value, consider a CSS language plugin that exposes a `:rule` pseudo-class matching only rule-type nodes:
+
+```js
+getSelectorClassNodeTypes(className) {
+    if (className === "rule") {
+        return ["StyleRule", "AtRule"];
+    }
+    return null;
+}
+```
+
+Without this interface method, the CSS plugin would need to request a core change to add its own hardcoded mapping — exactly the coupling this proposal eliminates.
 
 ### Core `esquery.js` Changes
 
@@ -120,7 +139,7 @@ The `analyzeParsedSelector()` function (currently at [line 148](https://github.c
 -                ];
 -            }
 -            return null;
-+            return language?.getPossibleTypesForSelectorClass?.(selector.name) ?? null;
++            return language?.getSelectorClassNodeTypes?.(selector.name) ?? null;
      }
  }
 ```
@@ -164,7 +183,7 @@ The exported `parse()` function (currently at [line 288](https://github.com/esli
 
 ### Language-Aware Selector Cache
 
-Currently, `esquery.js` uses a single global `Map` ([line 114](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L114): `const selectorCache = new Map()`) to cache parsed selectors. Since `getPossibleTypesForSelectorClass()` can return different results for different languages, the same selector string (e.g., `:function`) may produce different `nodeTypes` arrays depending on which language is active.
+Currently, `esquery.js` uses a single global `Map` ([line 114](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L114): `const selectorCache = new Map()`) to cache parsed selectors. Since `getSelectorClassNodeTypes()` can return different results for different languages, the same selector string (e.g., `:function`) may produce different `nodeTypes` arrays depending on which language is active.
 
 The cache is replaced with a `WeakMap` keyed by language object, so each language gets its own `Map<string, ESQueryParsedSelector>`:
 
@@ -189,7 +208,7 @@ function getLanguageCache(language) {
 }
 ```
 
-Using `WeakMap` ensures that language objects can be garbage collected when they're no longer in use, preventing memory leaks. The `noLanguageCache` provides backwards compatibility for any code that calls `parse()` without a language argument.
+Using `WeakMap` ensures that language objects can be garbage collected when they're no longer in use, preventing memory leaks. Using object identity (rather than a nested `Map` keyed by language IDs) also avoids introducing a language identifier requirement into the `Language` interface. The `noLanguageCache` provides backwards compatibility for any code that calls `parse()` without a language argument.
 
 Note: In practice, ESLint currently only uses one language per file (see [source-code-traverser.js line 269-275](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L269-L275)), but a multi-language lint run will process different files with different languages sequentially, so the per-language cache prevents stale optimization data from being reused across languages.
 
@@ -230,25 +249,25 @@ The [`SourceCodeTraverser`](https://github.com/eslint/eslint/blob/main/lib/linte
 
 1. **Increased Language interface surface.** Adding a new optional method increases the size of the Language contract. However, it is optional with a safe fallback, so existing language implementations are unaffected.
 
-2. **Potential for inconsistency.** A language could implement `matchesSelectorClass()` and `getPossibleTypesForSelectorClass()` inconsistently (e.g., `matchesSelectorClass` handles `:function` but `getPossibleTypesForSelectorClass` doesn't list the right types). However, the consequence of inconsistency is only reduced optimization (more nodes checked than necessary), not incorrect behavior, because `matchesSelectorClass` is still the source of truth for actual matching.
+2. **Potential for inconsistency.** A language could implement `matchesSelectorClass()` and `getSelectorClassNodeTypes()` inconsistently (e.g., `matchesSelectorClass` handles `:function` but `getSelectorClassNodeTypes` doesn't list the right types). The consequence of such inconsistency is only reduced optimization (more nodes checked than necessary), not incorrect behavior. This is a major design strength: static analysis is advisory only, and runtime matching via `matchesSelectorClass()` remains authoritative. Under this design, plugin authors cannot cause false negatives through an imprecise `getSelectorClassNodeTypes()` implementation. At worst, the traverser checks more nodes than strictly necessary. The only way incorrect behavior could arise is if ESLint core itself misused the static analysis results to skip runtime matching, which this design explicitly avoids.
 
 3. **Cache complexity.** The cache changes from a simple global `Map` to a `WeakMap` of `Map`s. This is slightly more complex, but the added complexity is minimal and localized to `esquery.js`.
 
-4. **Small scope.** As noted by the ESLint maintainer, this is "a tiny corner of the codebase that doesn't get hit very often." The practical benefit of this change is primarily architectural cleanliness rather than a significant feature or performance win.
+4. **Small scope.** The current optimization affects a relatively small part of the selector pipeline, so the primary benefit of this proposal is architectural consistency and extensibility rather than a large performance gain.
 
 ## Backwards Compatibility
 
 This change is **fully backwards compatible**:
 
-1. **`getPossibleTypesForSelectorClass()` is optional.** If a language does not implement it, the core falls back to `null` (match any type). This is the current behavior for all pseudo-classes except `:function` in JS.
+1. **`getSelectorClassNodeTypes()` is optional.** If a language does not implement it, the core falls back to `null` (match any type). This is the current behavior for all pseudo-classes except `:function` in JS.
 
-2. **JS behavior is preserved.** The JavaScript language object will implement `getPossibleTypesForSelectorClass()` with the exact same mapping currently hardcoded in `esquery.js`. End users will see no behavioral difference.
+2. **JS behavior is preserved.** The JavaScript language object will implement `getSelectorClassNodeTypes()` with the exact same mapping currently hardcoded in `esquery.js`. End users will see no behavioral difference.
 
 3. **`parse()` API is backwards compatible.** The `language` parameter is optional. Calling `parse(source)` without a language continues to work, using the `noLanguageCache` with `null` node types for class selectors.
 
 4. **No breaking changes for language plugins.** Existing language plugins (CSS, Markdown, JSON, HTML, YAML) do not need to implement this method. They will simply not benefit from the optimization until they choose to.
 
-5. **Type definitions.** The method is added as an optional property (`getPossibleTypesForSelectorClass?`) in `@eslint/core`'s `Language` interface, so existing TypeScript users are unaffected.
+5. **Type definitions.** The method is added as an optional property (`getSelectorClassNodeTypes?`) in `@eslint/core`'s `Language` interface, so existing TypeScript users are unaffected.
 
 ## Alternatives
 
@@ -259,7 +278,7 @@ Move the hardcoded logic into a helper function that checks the language identit
 ### 2. Use `matchesSelectorClass()` for Static Analysis
 
 Instead of adding a new method, try to infer possible types by calling `matchesSelectorClass()` against a set of known node types. This is impractical because:
-- The set of possible node types is unbounded (any language can define any node types).
+- ESLint core has no canonical registry of all node types for arbitrary languages, so exhaustive inference would require language-specific enumeration anyway.
 - It would require instantiating dummy nodes for every possible type.
 - It conflates runtime matching with static analysis.
 
@@ -270,19 +289,15 @@ Instead of a separate method, modify `matchesSelectorClass()` to optionally retu
 
 ## Open Questions
 
-1. **Method naming.** The proposed name `getPossibleTypesForSelectorClass` is descriptive but verbose. Alternatives considered:
-   - `getNodeTypesForClass(className)` — shorter, but less clear about "possible" semantics
-   - `selectorClassNodeTypes(className)` — property-style naming
-   
-   The longer name was chosen for clarity, matching the style of `matchesSelectorClass`. The team may prefer a different name.
+1. **Method naming.** The proposed name `getSelectorClassNodeTypes` was chosen for conciseness and alignment with ESLint core conventions. It is directly tied to selector classes, avoids the unnecessary "possible" qualifier (static analysis inherently implies possibility, not certainty), and keeps the return semantics clear from the documented contract. The team may prefer a different name.
 
-2. **Should language authors be encouraged to implement this for all their pseudo-classes?** For pseudo-classes that match based on type-name patterns (like `:statement` matching `*Statement`), returning `null` is correct since we can't enumerate all types. Should the documentation explicitly guide authors on when to return `null` vs. an explicit list?
+2. **Should language authors be encouraged to implement this for all their pseudo-classes?** For pseudo-classes defined by structural or naming conventions (like `:statement` matching `*Statement`), returning `null` is appropriate since the matching set is open-ended. Should the documentation explicitly guide authors on when to return `null` vs. an explicit list?
 
 3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language object is garbage collected. In practice, language objects are long-lived (often singletons). Should we consider adding a size limit to per-language caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
 
 ## Help Needed
 
-I am willing to submit a pull request with the reference implementation for this RFC once it is accepted. Performance benchmarking (using `npm run test:performance`) will be done to confirm there is no regression.
+I am willing to submit a pull request with the reference implementation for this RFC once it is accepted. The change should be performance-neutral outside selector parsing and traversal narrowing.
 
 ## Frequently Asked Questions
 
@@ -292,7 +307,7 @@ A: While the immediate benefit is architectural, making this change now is low-r
 
 **Q: Does this change affect how `matchesSelectorClass()` works?**
 
-A: No. `matchesSelectorClass()` continues to handle runtime matching exactly as before. `getPossibleTypesForSelectorClass()` is a separate, complementary method used only during selector parsing for static analysis.
+A: No. `matchesSelectorClass()` continues to handle runtime matching exactly as before. `getSelectorClassNodeTypes()` is a separate, complementary method used only during selector parsing for static analysis.
 
 ## Related Discussions
 

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -121,11 +121,11 @@ Without this interface method, the CSS plugin would need to request a core chang
 
 ### Core `esquery.js` Changes
 
-The `analyzeParsedSelector()` function (currently at [line 148](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L148)) is updated to accept a `language` parameter, which is passed into the inner `analyzeSelector()` closure:
+The `analyzeParsedSelector()` function (currently at [line 148](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L148)) is updated to accept a `getSelectorClassNodeTypes` parameter, which is passed into the inner `analyzeSelector()` closure:
 
 ```diff
 -function analyzeParsedSelector(parsedSelector) {
-+function analyzeParsedSelector(parsedSelector, language) {
++function analyzeParsedSelector(parsedSelector, getSelectorClassNodeTypes) {
      // ...
      function analyzeSelector(selector) {
          // ...
@@ -139,21 +139,21 @@ The `analyzeParsedSelector()` function (currently at [line 148](https://github.c
 -                ];
 -            }
 -            return null;
-+            return language?.getSelectorClassNodeTypes?.(selector.name) ?? null;
++            return getSelectorClassNodeTypes?.(selector.name) ?? null;
      }
  }
 ```
 
-The optional chaining (`?.`) ensures that if `language` is `undefined` or doesn't implement the method, the result is `null` — meaning "any node type could match," which is the safe fallback.
+The optional chaining (`?.`) ensures that if `getSelectorClassNodeTypes` is `undefined` (i.e. the method wasn't provided), the result is `null` — meaning "any node type could match," which is the safe fallback.
 
-The exported `parse()` function (currently at [line 288](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L288)) is updated to accept an optional `language` parameter and pass it through:
+The exported `parse()` function (currently at [line 288](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L288)) is updated to accept an optional `getSelectorClassNodeTypes` parameter and pass it through:
 
 ```diff
 -function parse(source) {
 -    if (selectorCache.has(source)) {
 -        return selectorCache.get(source);
-+function parse(source, language) {
-+    const cache = getLanguageCache(language);
++function parse(source, getSelectorClassNodeTypes) {
++    const cache = getMethodCache(getSelectorClassNodeTypes);
 +
 +    if (cache.has(source)) {
 +        return cache.get(source);
@@ -164,7 +164,7 @@ The exported `parse()` function (currently at [line 288](https://github.com/esli
          trySimpleParseSelector(cleanSource) ?? tryParseSelector(cleanSource);
      const { nodeTypes, attributeCount, identifierCount } =
 -        analyzeParsedSelector(parsedSelector);
-+        analyzeParsedSelector(parsedSelector, language);
++        analyzeParsedSelector(parsedSelector, getSelectorClassNodeTypes);
 
      const result = new ESQueryParsedSelector(
          source,
@@ -181,42 +181,44 @@ The exported `parse()` function (currently at [line 288](https://github.com/esli
  }
 ```
 
-### Language-Aware Selector Cache
+### Method-Keyed Selector Cache
 
 Currently, `esquery.js` uses a single global `Map` ([line 114](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L114): `const selectorCache = new Map()`) to cache parsed selectors. Since `getSelectorClassNodeTypes()` can return different results for different languages, the same selector string (e.g., `:function`) may produce different `nodeTypes` arrays depending on which language is active.
 
-The cache is replaced with a `WeakMap` keyed by language object, so each language gets its own `Map<string, ESQueryParsedSelector>`:
+The cache is replaced with a `WeakMap` keyed by the language's `getSelectorClassNodeTypes` method reference, so each language gets its own `Map<string, ESQueryParsedSelector>`:
 
 ```js
 // Replaces: const selectorCache = new Map();
-const selectorCacheByLanguage = new WeakMap();
-const noLanguageCache = new Map();
+const selectorCacheByMethod = new WeakMap();
+const noMethodCache = new Map();
 
-function getLanguageCache(language) {
-    if (!language) {
-        return noLanguageCache;
+function getMethodCache(getSelectorClassNodeTypes) {
+    if (!getSelectorClassNodeTypes) {
+        return noMethodCache;
     }
 
-    let cache = selectorCacheByLanguage.get(language);
+    let cache = selectorCacheByMethod.get(getSelectorClassNodeTypes);
 
     if (!cache) {
         cache = new Map();
-        selectorCacheByLanguage.set(language, cache);
+        selectorCacheByMethod.set(getSelectorClassNodeTypes, cache);
     }
 
     return cache;
 }
 ```
 
-Using `WeakMap` ensures that language objects can be garbage collected when they're no longer in use, preventing memory leaks. Using object identity (rather than a nested `Map` keyed by language IDs) also avoids introducing a language identifier requirement into the `Language` interface. The `noLanguageCache` provides backwards compatibility for any code that calls `parse()` without a language argument.
+ESLint languages are exported as singleton object literals (e.g., `lib/languages/js/index.js` exports its language as a `module.exports` object literal), so the method reference is stable for the lifetime of the process. Keying on the method therefore gives each language its own cache bucket without requiring a language identifier on the `Language` interface.
 
-Note: In practice, ESLint currently only uses one language per file (see [source-code-traverser.js line 269-275](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L269-L275)), but a multi-language lint run will process different files with different languages sequentially, so the per-language cache prevents stale optimization data from being reused across languages.
+Using `WeakMap` ensures that if a language (and hence its method) is no longer reachable, it can be garbage collected, preventing memory leaks. The `noMethodCache` provides backwards compatibility for any code that calls `parse(source)` without providing a method.
+
+Note: In practice, ESLint currently only uses one language per file (see [source-code-traverser.js line 269-275](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L269-L275)), but a multi-language lint run will process different files with different languages sequentially, so the method-keyed cache prevents stale optimization data from being reused across languages.
 
 ### Source Code Traverser Changes
 
 The [`SourceCodeTraverser`](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js) already stores the language as a private field `#language` (set in the constructor at [line 249](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L249)). The only changes needed are:
 
-1. Pass the language through the `esqueryOptions` object when constructing `ESQueryHelper`:
+1. Pass the method directly through the `esqueryOptions` object when constructing `ESQueryHelper`, consistent with how `matchesSelectorClass`, `visitorKeys`, and `nodeTypeKey` are already passed individually:
 
 ```diff
  // In SourceCodeTraverser.traverseSync() (line 269)
@@ -226,20 +228,20 @@ The [`SourceCodeTraverser`](https://github.com/eslint/eslint/blob/main/lib/linte
          fallback: vk.getKeys,
          matchClass: this.#language.matchesSelectorClass ?? (() => false),
          nodeTypeKey: this.#language.nodeTypeKey,
-+        language: this.#language,
++        getSelectorClassNodeTypes: this.#language.getSelectorClassNodeTypes,
      });
 ```
 
-2. In the `ESQueryHelper` constructor, store the language and pass it to `parse()`:
+2. In the `ESQueryHelper` constructor, store the method and pass it to `parse()`:
 
 ```diff
  // In ESQueryHelper constructor (line 52)
  constructor(visitor, esqueryOptions) {
-+    this.language = esqueryOptions.language;
++    this.getSelectorClassNodeTypes = esqueryOptions.getSelectorClassNodeTypes;
      // ...
      visitor.forEachName(rawSelector => {
 -        const selector = parse(rawSelector);
-+        const selector = parse(rawSelector, this.language);
++        const selector = parse(rawSelector, this.getSelectorClassNodeTypes);
          // ... rest unchanged
      });
  }
@@ -263,7 +265,7 @@ This change is **fully backwards compatible**:
 
 2. **JS behavior is preserved.** The JavaScript language object will implement `getSelectorClassNodeTypes()` with the exact same mapping currently hardcoded in `esquery.js`. End users will see no behavioral difference.
 
-3. **`parse()` API is backwards compatible.** The `language` parameter is optional. Calling `parse(source)` without a language continues to work, using the `noLanguageCache` with `null` node types for class selectors.
+3. **`parse()` API is backwards compatible.** The `getSelectorClassNodeTypes` parameter is optional. Calling `parse(source)` without it continues to work, using the `noMethodCache` with `null` node types for class selectors.
 
 4. **No breaking changes for language plugins.** Existing language plugins (CSS, Markdown, JSON, HTML, YAML) do not need to implement this method. They will simply not benefit from the optimization until they choose to.
 
@@ -293,7 +295,7 @@ Instead of a separate method, modify `matchesSelectorClass()` to optionally retu
 
 2. **Should language authors be encouraged to implement this for all their pseudo-classes?** For pseudo-classes defined by structural or naming conventions (like `:statement` matching `*Statement`), returning `null` is appropriate since the matching set is open-ended. Should the documentation explicitly guide authors on when to return `null` vs. an explicit list?
 
-3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language object is garbage collected. In practice, language objects are long-lived (often singletons). Should we consider adding a size limit to per-language caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
+3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language's `getSelectorClassNodeTypes` method becomes unreachable. In practice, language objects (and their methods) are long-lived (often singletons). Should we consider adding a size limit to per-method caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
 
 ## Help Needed
 

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -139,12 +139,12 @@ The `analyzeParsedSelector()` function (currently at [line 148](https://github.c
 -                ];
 -            }
 -            return null;
-+            return getSelectorClassNodeTypes?.(selector.name) ?? null;
++            return getSelectorClassNodeTypes(selector.name) ?? null;
      }
  }
 ```
 
-The optional chaining (`?.`) ensures that if `getSelectorClassNodeTypes` is `undefined` (i.e. the method wasn't provided), the result is `null` — meaning "any node type could match," which is the safe fallback.
+Because `parse()` defaults `getSelectorClassNodeTypes` to a shared no-op function (see "Method-Keyed Selector Cache" below), the method is always callable here — no optional chaining needed. The trailing `?? null` preserves the "any node type could match" fallback for the no-op case (which returns `null`) and for any language method that explicitly returns `null`.
 
 The exported `parse()` function (currently at [line 288](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L288)) is updated to accept an optional `getSelectorClassNodeTypes` parameter and pass it through:
 
@@ -152,7 +152,7 @@ The exported `parse()` function (currently at [line 288](https://github.com/esli
 -function parse(source) {
 -    if (selectorCache.has(source)) {
 -        return selectorCache.get(source);
-+function parse(source, getSelectorClassNodeTypes) {
++function parse(source, getSelectorClassNodeTypes = NO_OP_SELECTOR_CLASS) {
 +    const cache = getMethodCache(getSelectorClassNodeTypes);
 +
 +    if (cache.has(source)) {
@@ -189,28 +189,22 @@ The cache is replaced with a `WeakMap` keyed by the language's `getSelectorClass
 
 ```js
 // Replaces: const selectorCache = new Map();
+const NO_OP_SELECTOR_CLASS = () => null;
 const selectorCacheByMethod = new WeakMap();
-const noMethodCache = new Map();
 
 function getMethodCache(getSelectorClassNodeTypes) {
-    if (!getSelectorClassNodeTypes) {
-        return noMethodCache;
-    }
-
     let cache = selectorCacheByMethod.get(getSelectorClassNodeTypes);
-
     if (!cache) {
         cache = new Map();
         selectorCacheByMethod.set(getSelectorClassNodeTypes, cache);
     }
-
     return cache;
 }
 ```
 
 ESLint languages are exported as singleton object literals (e.g., `lib/languages/js/index.js` exports its language as a `module.exports` object literal), so the method reference is stable for the lifetime of the process. Keying on the method therefore gives each language its own cache bucket without requiring a language identifier on the `Language` interface.
 
-Using `WeakMap` ensures that if a language (and hence its method) is no longer reachable, it can be garbage collected, preventing memory leaks. The `noMethodCache` provides backwards compatibility for any code that calls `parse(source)` without providing a method.
+Using `WeakMap` ensures that if a language (and hence its method) is no longer reachable, it can be garbage collected, preventing memory leaks. Languages that do not implement `getSelectorClassNodeTypes` use a shared `NO_OP_SELECTOR_CLASS` function as the default at the `parse()` boundary. All such languages share one cache bucket, which is correct because they all produce the same (null) static-analysis result. This eliminates a separate fallback cache and keeps `getMethodCache` free of special cases.
 
 Note: In practice, ESLint currently only uses one language per file (see [source-code-traverser.js line 269-275](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L269-L275)), but a multi-language lint run will process different files with different languages sequentially, so the method-keyed cache prevents stale optimization data from being reused across languages.
 
@@ -265,7 +259,7 @@ This change is **fully backwards compatible**:
 
 2. **JS behavior is preserved.** The JavaScript language object will implement `getSelectorClassNodeTypes()` with the exact same mapping currently hardcoded in `esquery.js`. End users will see no behavioral difference.
 
-3. **`parse()` API is backwards compatible.** The `getSelectorClassNodeTypes` parameter is optional. Calling `parse(source)` without it continues to work, using the `noMethodCache` with `null` node types for class selectors.
+3. **`parse()` API is backwards compatible.** The `getSelectorClassNodeTypes` parameter is optional and defaults to a shared no-op function. Calling `parse(source)` without it continues to work; class selectors receive `null` node types, identical to the pre-change behavior for all non-`:function` selectors.
 
 4. **No breaking changes for language plugins.** Existing language plugins (CSS, Markdown, JSON, HTML, YAML) do not need to implement this method. They will simply not benefit from the optimization until they choose to.
 
@@ -295,7 +289,7 @@ Instead of a separate method, modify `matchesSelectorClass()` to optionally retu
 
 2. **Should language authors be encouraged to implement this for all their pseudo-classes?** For pseudo-classes defined by structural or naming conventions (like `:statement` matching `*Statement`), returning `null` is appropriate since the matching set is open-ended. Should the documentation explicitly guide authors on when to return `null` vs. an explicit list?
 
-3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language's `getSelectorClassNodeTypes` method becomes unreachable. In practice, language objects (and their methods) are long-lived (often singletons). Should we consider adding a size limit to per-method caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
+3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language's `getSelectorClassNodeTypes` method becomes unreachable. In practice, language objects (and their methods) are long-lived (often singletons). Languages without the method share a single cache bucket keyed on the module-level `NO_OP_SELECTOR_CLASS`. Should we consider adding a size limit to per-method caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
 
 ## Help Needed
 

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -1,0 +1,304 @@
+- Repo: eslint/eslint
+- Start Date: 2026-05-23
+- RFC PR: (fill in after PR is created)
+- Authors: [Kuldeep2822k](https://github.com/Kuldeep2822k)
+
+# Add `getPossibleTypesForSelectorClass` to the Language Interface
+
+## Summary
+
+Add an optional `getPossibleTypesForSelectorClass(className)` method to the `Language` interface that allows languages to declare which AST node types could match a given pseudo-class selector (e.g., `:function`). This removes hardcoded JavaScript-specific logic from the core selector analysis in `lib/linter/esquery.js` and enables any language plugin to provide the same optimization.
+
+## Motivation
+
+ESLint's core selector engine ([`lib/linter/esquery.js`](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js)) performs static analysis on parsed selectors to determine which AST node types could possibly trigger them. This is a performance optimization: if a selector like `:function` can only match `FunctionDeclaration`, `FunctionExpression`, and `ArrowFunctionExpression` nodes, the traverser can skip invoking the selector's matching logic on all other node types.
+
+However, there is currently a hardcoded JavaScript-specific mapping for the `:function` pseudo-class:
+
+```js
+// lib/linter/esquery.js, lines 208-217
+case "class":
+    // TODO: abstract into JSLanguage somehow
+    if (selector.name === "function") {
+        return [
+            "FunctionDeclaration",
+            "FunctionExpression",
+            "ArrowFunctionExpression",
+        ];
+    }
+    return null;
+```
+
+This presents several problems:
+
+1. **Language-agnostic roadmap conflict.** The Language interface was designed ([RFC #99](https://github.com/eslint/rfcs/pull/99)) to make ESLint language-agnostic. Having JS-specific logic in the core selector engine contradicts this goal.
+
+2. **Missing optimization for other languages.** The Language interface already provides `matchesSelectorClass()` for _runtime_ matching of nodes against pseudo-classes. However, there is no companion method for _static analysis_ — determining upfront which node types a pseudo-class could possibly match. Languages like CSS, Markdown, JSON, HTML, and YAML that implement custom pseudo-classes cannot benefit from this traversal optimization.
+
+3. **Maintenance concern.** The existing `TODO` comment explicitly acknowledges this code doesn't belong in the core. As more languages are added, having JS-specific logic in the core linter becomes increasingly confusing for contributors.
+
+The Language interface already has a precedent for this pattern: `matchesSelectorClass()` handles runtime matching, and the proposed `getPossibleTypesForSelectorClass()` would handle static analysis. Together, they provide a complete, language-agnostic pseudo-class system.
+
+## Detailed Design
+
+This proposal consists of the following changes:
+
+1. Add an optional `getPossibleTypesForSelectorClass()` method to the `Language` interface (in `@eslint/core`).
+2. Move the JS-specific `:function` mapping into `lib/languages/js/index.js`.
+3. Update `lib/linter/esquery.js` to call the language method instead of using hardcoded logic.
+4. Make the selector cache language-aware.
+
+### The `getPossibleTypesForSelectorClass()` Method
+
+A new optional method is added to the `Language` interface:
+
+```ts
+interface Language {
+    // ... existing properties ...
+
+    /**
+     * Returns the AST node types that could possibly match a given
+     * pseudo-class selector. Used for static analysis of selectors
+     * to optimize traversal by narrowing which node types need to
+     * be checked.
+     *
+     * @param className The name of the pseudo-class (e.g., "function").
+     * @returns An array of node type strings that could match, or
+     *          `null` if all node types could potentially match.
+     */
+    getPossibleTypesForSelectorClass?(className: string): string[] | null;
+}
+```
+
+**Return value semantics:**
+
+- **`string[]`** — Only nodes of these types could match the pseudo-class. The traverser will only check these node types, skipping all others.
+- **`null`** — Any node type could match. The traverser must check every node (this is the safe fallback).
+
+**If a language does not implement this method**, the core falls back to returning `null` for all class selectors, which is functionally equivalent to the current behavior for all pseudo-classes _except_ `:function` in JS. This means no existing language is negatively affected.
+
+### JavaScript Language Implementation
+
+The JS language object in [`lib/languages/js/index.js`](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js) would implement this method alongside the existing `matchesSelectorClass()`:
+
+```js
+getPossibleTypesForSelectorClass(className) {
+    if (className === "function") {
+        return [
+            "FunctionDeclaration",
+            "FunctionExpression",
+            "ArrowFunctionExpression",
+        ];
+    }
+    return null;
+}
+```
+
+This is a direct extraction of the logic currently hardcoded in `esquery.js` (line 210: `if (selector.name === "function")`). Note that the existing hardcoded check uses a case-sensitive comparison (`===`), and so does this implementation to maintain the same behavior. The `className` parameter receives the raw `selector.name` value from the esquery parsed AST, which preserves the casing as written in the selector string (e.g., `:function` → `"function"`).
+
+The existing `matchesSelectorClass()` in the JS language already handles runtime matching for classes like `statement`, `declaration`, `pattern`, `expression`, and `function` (see [lines 163-229](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js#L163-L229)). This new method provides the static type analysis companion.
+
+Note: The other pseudo-classes (`statement`, `declaration`, `pattern`, `expression`) return `null` from the static analysis (meaning "any type could match") because they match based on suffix patterns (e.g., any type ending in `"Statement"`) or complex conditions involving ancestry. We cannot statically enumerate all possible node types for these classes. Only `:function`, which matches a fixed set of three specific types, benefits from this optimization.
+
+### Core `esquery.js` Changes
+
+The `analyzeParsedSelector()` function (currently at [line 148](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L148)) is updated to accept a `language` parameter, which is passed into the inner `analyzeSelector()` closure:
+
+```diff
+-function analyzeParsedSelector(parsedSelector) {
++function analyzeParsedSelector(parsedSelector, language) {
+     // ...
+     function analyzeSelector(selector) {
+         // ...
+         case "class":
+-            // TODO: abstract into JSLanguage somehow
+-            if (selector.name === "function") {
+-                return [
+-                    "FunctionDeclaration",
+-                    "FunctionExpression",
+-                    "ArrowFunctionExpression",
+-                ];
+-            }
+-            return null;
++            return language?.getPossibleTypesForSelectorClass?.(selector.name) ?? null;
+     }
+ }
+```
+
+The optional chaining (`?.`) ensures that if `language` is `undefined` or doesn't implement the method, the result is `null` — meaning "any node type could match," which is the safe fallback.
+
+The exported `parse()` function (currently at [line 288](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L288)) is updated to accept an optional `language` parameter and pass it through:
+
+```diff
+-function parse(source) {
+-    if (selectorCache.has(source)) {
+-        return selectorCache.get(source);
++function parse(source, language) {
++    const cache = getLanguageCache(language);
++
++    if (cache.has(source)) {
++        return cache.get(source);
+     }
+
+     const cleanSource = source.replace(/:exit$/u, "");
+     const parsedSelector =
+         trySimpleParseSelector(cleanSource) ?? tryParseSelector(cleanSource);
+     const { nodeTypes, attributeCount, identifierCount } =
+-        analyzeParsedSelector(parsedSelector);
++        analyzeParsedSelector(parsedSelector, language);
+
+     const result = new ESQueryParsedSelector(
+         source,
+         source.endsWith(":exit"),
+         parsedSelector,
+         nodeTypes,
+         attributeCount,
+         identifierCount,
+     );
+
+-    selectorCache.set(source, result);
++    cache.set(source, result);
+     return result;
+ }
+```
+
+### Language-Aware Selector Cache
+
+Currently, `esquery.js` uses a single global `Map` ([line 114](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L114): `const selectorCache = new Map()`) to cache parsed selectors. Since `getPossibleTypesForSelectorClass()` can return different results for different languages, the same selector string (e.g., `:function`) may produce different `nodeTypes` arrays depending on which language is active.
+
+The cache is replaced with a `WeakMap` keyed by language object, so each language gets its own `Map<string, ESQueryParsedSelector>`:
+
+```js
+// Replaces: const selectorCache = new Map();
+const selectorCacheByLanguage = new WeakMap();
+const noLanguageCache = new Map();
+
+function getLanguageCache(language) {
+    if (!language) {
+        return noLanguageCache;
+    }
+
+    let cache = selectorCacheByLanguage.get(language);
+
+    if (!cache) {
+        cache = new Map();
+        selectorCacheByLanguage.set(language, cache);
+    }
+
+    return cache;
+}
+```
+
+Using `WeakMap` ensures that language objects can be garbage collected when they're no longer in use, preventing memory leaks. The `noLanguageCache` provides backwards compatibility for any code that calls `parse()` without a language argument.
+
+Note: In practice, ESLint currently only uses one language per file (see [source-code-traverser.js line 269-275](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L269-L275)), but a multi-language lint run will process different files with different languages sequentially, so the per-language cache prevents stale optimization data from being reused across languages.
+
+### Source Code Traverser Changes
+
+The [`SourceCodeTraverser`](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js) already stores the language as a private field `#language` (set in the constructor at [line 249](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L249)). The only changes needed are:
+
+1. Pass the language through the `esqueryOptions` object when constructing `ESQueryHelper`:
+
+```diff
+ // In SourceCodeTraverser.traverseSync() (line 269)
+ traverseSync(sourceCode, visitor, { steps } = {}) {
+     const esquery = new ESQueryHelper(visitor, {
+         visitorKeys: sourceCode.visitorKeys ?? this.#language.visitorKeys,
+         fallback: vk.getKeys,
+         matchClass: this.#language.matchesSelectorClass ?? (() => false),
+         nodeTypeKey: this.#language.nodeTypeKey,
++        language: this.#language,
+     });
+```
+
+2. In the `ESQueryHelper` constructor, store the language and pass it to `parse()`:
+
+```diff
+ // In ESQueryHelper constructor (line 52)
+ constructor(visitor, esqueryOptions) {
++    this.language = esqueryOptions.language;
+     // ...
+     visitor.forEachName(rawSelector => {
+-        const selector = parse(rawSelector);
++        const selector = parse(rawSelector, this.language);
+         // ... rest unchanged
+     });
+ }
+```
+
+## Drawbacks
+
+1. **Increased Language interface surface.** Adding a new optional method increases the size of the Language contract. However, it is optional with a safe fallback, so existing language implementations are unaffected.
+
+2. **Potential for inconsistency.** A language could implement `matchesSelectorClass()` and `getPossibleTypesForSelectorClass()` inconsistently (e.g., `matchesSelectorClass` handles `:function` but `getPossibleTypesForSelectorClass` doesn't list the right types). However, the consequence of inconsistency is only reduced optimization (more nodes checked than necessary), not incorrect behavior, because `matchesSelectorClass` is still the source of truth for actual matching.
+
+3. **Cache complexity.** The cache changes from a simple global `Map` to a `WeakMap` of `Map`s. This is slightly more complex, but the added complexity is minimal and localized to `esquery.js`.
+
+4. **Small scope.** As noted by the ESLint maintainer, this is "a tiny corner of the codebase that doesn't get hit very often." The practical benefit of this change is primarily architectural cleanliness rather than a significant feature or performance win.
+
+## Backwards Compatibility
+
+This change is **fully backwards compatible**:
+
+1. **`getPossibleTypesForSelectorClass()` is optional.** If a language does not implement it, the core falls back to `null` (match any type). This is the current behavior for all pseudo-classes except `:function` in JS.
+
+2. **JS behavior is preserved.** The JavaScript language object will implement `getPossibleTypesForSelectorClass()` with the exact same mapping currently hardcoded in `esquery.js`. End users will see no behavioral difference.
+
+3. **`parse()` API is backwards compatible.** The `language` parameter is optional. Calling `parse(source)` without a language continues to work, using the `noLanguageCache` with `null` node types for class selectors.
+
+4. **No breaking changes for language plugins.** Existing language plugins (CSS, Markdown, JSON, HTML, YAML) do not need to implement this method. They will simply not benefit from the optimization until they choose to.
+
+5. **Type definitions.** The method is added as an optional property (`getPossibleTypesForSelectorClass?`) in `@eslint/core`'s `Language` interface, so existing TypeScript users are unaffected.
+
+## Alternatives
+
+### 1. Do Nothing (Status Quo)
+
+Leave the hardcoded JS logic in `esquery.js` with the `TODO` comment. This is the simplest approach, and the maintainer has acknowledged the current state is acceptable. However, it leaves a known architectural debt and prevents other languages from benefiting from the same optimization.
+
+### 2. Move Logic Without a Language Interface Method
+
+Move the hardcoded logic into a helper function that checks the language identity (e.g., `if (language === jsLanguage)`) rather than adding a generic interface method. This removes the hardcoding from `esquery.js` but doesn't provide a generic solution for other languages and still couples the core to the JS language.
+
+### 3. Use `matchesSelectorClass()` for Static Analysis
+
+Instead of adding a new method, try to infer possible types by calling `matchesSelectorClass()` against a set of known node types. This is impractical because:
+- The set of possible node types is unbounded (any language can define any node types).
+- It would require instantiating dummy nodes for every possible type.
+- It conflates runtime matching with static analysis.
+
+### 4. Extend `matchesSelectorClass()` to Return Type Information
+
+Instead of a separate method, modify `matchesSelectorClass()` to optionally return type information. This was rejected because it changes the semantics of an existing method and makes the return type complex (boolean vs. type array).
+
+## Open Questions
+
+1. **Method naming.** The proposed name `getPossibleTypesForSelectorClass` is descriptive but verbose. Alternatives considered:
+   - `getNodeTypesForClass(className)` — shorter, but less clear about "possible" semantics
+   - `selectorClassNodeTypes(className)` — property-style naming
+   
+   The longer name was chosen for clarity, matching the style of `matchesSelectorClass`. The team may prefer a different name.
+
+2. **Should language authors be encouraged to implement this for all their pseudo-classes?** For pseudo-classes that match based on type-name patterns (like `:statement` matching `*Statement`), returning `null` is correct since we can't enumerate all types. Should the documentation explicitly guide authors on when to return `null` vs. an explicit list?
+
+3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language object is garbage collected. In practice, language objects are long-lived (often singletons). Should we consider adding a size limit to per-language caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
+
+## Help Needed
+
+I am willing to submit a pull request with the reference implementation for this RFC once it is accepted. Performance benchmarking (using `npm run test:performance`) will be done to confirm there is no regression.
+
+## Frequently Asked Questions
+
+**Q: Why not wait until there's a concrete non-JS language that needs this?**
+
+A: While the immediate benefit is architectural, making this change now is low-risk (fully backwards compatible, optional method) and avoids accumulating more JS-specific debt in the core. It also sends a clear signal to language plugin authors that the optimization path exists.
+
+**Q: Does this change affect how `matchesSelectorClass()` works?**
+
+A: No. `matchesSelectorClass()` continues to handle runtime matching exactly as before. `getPossibleTypesForSelectorClass()` is a separate, complementary method used only during selector parsing for static analysis.
+
+## Related Discussions
+
+- [Discussion #20856](https://github.com/eslint/eslint/discussions/20856) — Original discussion: "Should we move JS-specific ESQuery analysis logic into the Language interface?"
+- [RFC #99](https://github.com/eslint/rfcs/pull/99) — ESLint Language Plugins (introduced the Language interface)
+- [esquery External class resolve PR](https://github.com/estools/esquery/pull/140) — The mechanism that enabled `matchesSelectorClass()`

--- a/designs/2026-selector-class-types/README.md
+++ b/designs/2026-selector-class-types/README.md
@@ -3,20 +3,19 @@
 - RFC PR: https://github.com/eslint/rfcs/pull/148
 - Authors: Kuldeep2822k
 
-# Add `getSelectorClassNodeTypes` to the Language Interface
+# Add `selectorClassNodeTypes` to the Language Interface
 
 ## Summary
 
-Add an optional `getSelectorClassNodeTypes(className)` method to the Language interface that allows languages to declare which AST node types could match a given pseudo-class selector (e.g., `:function`). This removes hardcoded JavaScript-specific logic from the core selector analysis in `lib/linter/esquery.js` and enables any language plugin to participate in selector static analysis.
+This RFC proposes adding an optional `selectorClassNodeTypes` property (`Map<string, Array<string>>`) to the `Language` interface, so a language can declare which AST node types a pseudo-class selector (such as `:function`) can match. This moves JavaScript-specific selector analysis out of `lib/linter/esquery.js` and lets language plugins participate in selector static analysis.
 
 ## Motivation
 
-ESLint's core selector engine ([`lib/linter/esquery.js`](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js)) performs static analysis on parsed selectors to determine which AST node types could possibly trigger them. This is a performance optimization: if a selector like `:function` can only match `FunctionDeclaration`, `FunctionExpression`, and `ArrowFunctionExpression` nodes, the traverser can skip invoking the selector's matching logic on all other node types.
+When rules register selectors, ESLint's selector engine ([`lib/linter/esquery.js`](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js)) statically analyzes the parsed selector to find candidate AST node types. For example, `:function` only matches `FunctionDeclaration`, `FunctionExpression`, and `ArrowFunctionExpression`, so the traverser indexes the selector under those node types and skips selector matching on other nodes.
 
-However, there is currently a hardcoded JavaScript-specific mapping for the `:function` pseudo-class:
+Currently, this optimization is hardcoded for JavaScript functions in the `analyzeParsedSelector()` helper in `lib/linter/esquery.js`:
 
 ```js
-// lib/linter/esquery.js, lines 208-217
 case "class":
     // TODO: abstract into JSLanguage somehow
     if (selector.name === "function") {
@@ -29,142 +28,185 @@ case "class":
     return null;
 ```
 
-This presents several problems:
+This creates a few practical issues:
 
-1. **Language-agnostic roadmap conflict.** The Language interface was designed ([RFC #99](https://github.com/eslint/rfcs/pull/99)) to make ESLint language-agnostic. Having JS-specific logic in the core selector engine contradicts this goal.
+- **Language interface consistency.** RFC #99 established the `Language` interface so ESLint core remains agnostic to specific language syntax. Keeping JS-specific node names hardcoded in the core selector engine conflicts with that abstraction.
+- **Plugin parity.** `matchesSelectorClass()` allows language plugins to define runtime pseudo-class matching, but there is no mechanism for plugins to declare candidate node types for static analysis. Because the `case "class"` branch is hardcoded, `:function` narrows to the JS function node types regardless of the active language, while every other class selector returns `null`, so language plugins can't declare candidate node types to narrow traversal.
+- **Direct TODO in core.** The comment in `esquery.js` explicitly notes that this mapping should be abstracted into the language implementation.
 
-2. **Incomplete selector-class extension API.** The current Language interface allows plugins to define runtime pseudo-class behavior through `matchesSelectorClass()`, but provides no mechanism for participating in selector static analysis. This means custom language plugins cannot integrate fully with ESLint's traversal optimization pipeline even when their pseudo-classes map to a finite set of node types. Without a static analysis companion, plugin authors would need to request core changes for every optimizable pseudo-class, and selector semantics would not be fully owned by the language implementation — contradicting the language-agnostic architecture.
-
-3. **Maintenance concern.** The existing `TODO` comment explicitly acknowledges this code doesn't belong in the core. As more languages are added, having JS-specific logic in the core linter becomes increasingly confusing for contributors.
-
-Selector analysis depends on selector semantics, and selector semantics are already delegated to language implementations through `matchesSelectorClass()`. Static analysis therefore belongs to the same abstraction boundary. The proposed `getSelectorClassNodeTypes()` completes this symmetry, providing a full, language-agnostic pseudo-class system where both runtime matching and static analysis are owned by the language implementation.
+Adding `selectorClassNodeTypes` to the `Language` interface moves this mapping to the language object, where pseudo-class semantics are already defined.
 
 ## Detailed Design
 
-This proposal consists of the following changes:
+I propose storing the pseudo-class-to-node-type mapping on the language object and having core read it during selector static analysis. The change touches three places: the `Language` interface, the JavaScript language object, and two spots in the selector engine.
 
-1. Add an optional `getSelectorClassNodeTypes()` method to the `Language` interface (in `@eslint/core`).
-2. Move the JS-specific `:function` mapping into `lib/languages/js/index.js`.
-3. Update `lib/linter/esquery.js` to call the language method instead of using hardcoded logic.
-4. Make the selector cache language-aware.
+### 1. `Language` Interface Property
 
-### The `getSelectorClassNodeTypes()` Method
-
-A new optional method is added to the `Language` interface:
+Add an optional `selectorClassNodeTypes` field to the `Language` interface in `@eslint/core`:
 
 ```ts
-interface Language {
+interface Language<Options extends LanguageTypeOptions = LanguageTypeOptions> {
     // ... existing properties ...
+    nodeTypeKey: string;
+    visitorKeys?: Record<string, readonly string[]>;
 
     /**
-     * Returns the AST node types that could possibly match a given
-     * pseudo-class selector. Used for static analysis of selectors
-     * to optimize traversal by narrowing which node types need to
-     * be checked.
-     *
-     * @param className The name of the pseudo-class (e.g., "function").
-     * @returns An array of node type strings that could match, or
-     *          `null` if all node types could potentially match.
+     * Map of lowercase selector class names to the AST node types that can match them.
+     * Used for static analysis to narrow candidate node types during traversal.
      */
-    getSelectorClassNodeTypes?(className: string): string[] | null;
+    selectorClassNodeTypes?: Map<string, Array<string>>;
+
+    matchesSelectorClass?(
+        className: string,
+        node: Options["Node"],
+        ancestry: Options["Node"][],
+    ): boolean;
 }
 ```
 
-**Return value semantics:**
+### 2. Static Analysis vs. Runtime Matching
 
-- **`string[]`** — Only nodes of these types could match the pseudo-class. The traverser will only invoke selector matching for these node types, skipping all others.
-- **`null`** — Any node type could match. The traverser must check every node (this is the safe fallback).
+Static analysis and runtime matching serve different roles.
 
-**If a language does not implement this method**, the core falls back to returning `null` for all class selectors, which is functionally equivalent to the current behavior for all pseudo-classes _except_ `:function` in JS. Existing language implementations remain unaffected.
+During selector parsing, `analyzeParsedSelector()` converts the class name to lowercase and looks it up with `selectorClassNodeTypes.get(selector.name.toLowerCase())`. If the class is in the map, it returns the array of node types, and the traverser indexes the selector under them (`enterSelectorsByNodeType` / `exitSelectorsByNodeType`). If the class is missing, or `selectorClassNodeTypes` is undefined, static analysis returns `null`, which places the selector in the traverser's any-type list (`anyTypeEnterSelectors` / `anyTypeExitSelectors`) and evaluates it on every node during traversal.
 
-**Semantic invariant:** For correctness, the set of node types returned by `getSelectorClassNodeTypes()` MUST be a superset of the types that actually match through `matchesSelectorClass()`. Returning extra types is allowed and only reduces optimization quality — the traverser checks more nodes than necessary, but never misses a match.
+During traversal, `matchesSelectorClass()` performs the actual match. A pseudo-class that returned `null` from static analysis, like `:statement`, is still filtered correctly here by matching only nodes ending in `Statement` or `Declaration`. An unknown class like `:foo` throws `Error: Unknown class name: foo`, as it does today.
 
-**Why `null` instead of `undefined`:** `null` is used intentionally to distinguish "all node types may match" (an explicit statement about the pseudo-class) from "method not implemented" (which is `undefined` via optional chaining). This prevents collapsing semantics between an explicitly non-optimizable pseudo-class and a missing method.
+The rule for plugin authors follows from this: the node types in `selectorClassNodeTypes` must cover every node type `matchesSelectorClass()` can match. When a pseudo-class is open-ended or dynamic, leave it out of the map so it falls back to `null` and evaluates against all nodes. Returning an empty array `[]` instead prunes the selector from traversal completely.
 
-### JavaScript Language Implementation
+### 3. JavaScript Language Implementation
 
-The JS language object in [`lib/languages/js/index.js`](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js) would implement this method alongside the existing `matchesSelectorClass()`:
+In `lib/languages/js/index.js`, export `selectorClassNodeTypes` on the JS language object:
 
 ```js
-getSelectorClassNodeTypes(className) {
-    if (className.toLowerCase() === "function") {
-        return [
-            "FunctionDeclaration",
-            "FunctionExpression",
-            "ArrowFunctionExpression",
-        ];
-    }
-    return null;
-}
+module.exports = {
+    fileType: "text",
+    lineStart: 1,
+    columnStart: 0,
+    nodeTypeKey: "type",
+    visitorKeys: evk.KEYS,
+
+    selectorClassNodeTypes: new Map([
+        [
+            "function",
+            [
+                "FunctionDeclaration",
+                "FunctionExpression",
+                "ArrowFunctionExpression",
+            ],
+        ],
+    ]),
+
+    matchesSelectorClass(className, node, ancestry) {
+        // ... existing implementation unchanged ...
+    },
+};
 ```
 
-This is a direct extraction of the logic currently hardcoded in `esquery.js` (line 210: `if (selector.name === "function")`). Note that the existing hardcoded check in `esquery.js` uses a case-sensitive comparison (`===`), but the runtime `matchesSelectorClass()` (line 191) uses `className.toLowerCase()` for case-insensitive matching. The proposed implementation uses `.toLowerCase()` to remain consistent with `matchesSelectorClass()`, since esquery's parser preserves the raw casing of `selector.name` (e.g., `:Function` → `"Function"`). The case-sensitive hardcoded check in `esquery.js` only works because selectors are conventionally lowercase; `getSelectorClassNodeTypes()` should handle edge cases consistently with the runtime method.
+Pseudo-classes with open-ended or pattern-based matching (`statement`, `declaration`, `pattern`, `expression`) are omitted from `selectorClassNodeTypes`, safely returning `null` during static analysis and relying on runtime matching.
 
-The existing `matchesSelectorClass()` in the JS language already handles runtime matching for classes like `statement`, `declaration`, `pattern`, `expression`, and `function` (see [lines 163-229](https://github.com/eslint/eslint/blob/main/lib/languages/js/index.js#L163-L229)). `getSelectorClassNodeTypes()` provides the static type analysis companion.
+### 4. Example: CSS Language Plugin
 
-Note: The other pseudo-classes (`statement`, `declaration`, `pattern`, `expression`) return `null` from the static analysis (meaning "any type could match") because they match based on suffix patterns (e.g., any type ending in `"Statement"`) or complex conditions involving ancestry. These pseudo-classes are defined by structural or naming conventions rather than a fixed closed set of node types, making enumeration language-specific and potentially brittle. Only `:function`, which maps to a fixed closed set of node types, benefits from this optimization.
-
-### Example: CSS Language Plugin
-
-To illustrate the extensibility value, consider a CSS language plugin that exposes a `:rule` pseudo-class matching only rule-type nodes:
+A CSS language plugin could declare candidate node types for its pseudo-classes:
 
 ```js
-getSelectorClassNodeTypes(className) {
-    if (className === "rule") {
-        return ["StyleRule", "AtRule"];
-    }
-    return null;
-}
+export const cssLanguage = {
+    fileType: "text",
+    nodeTypeKey: "type",
+    visitorKeys: {
+        StyleSheet: ["children"],
+        Rule: ["prelude", "block"],
+        Atrule: ["prelude", "block"],
+        Declaration: ["property", "value"],
+        Block: ["children"],
+    },
+
+    selectorClassNodeTypes: new Map([
+        ["rule", ["Rule", "Atrule"]],
+        ["at-rule", ["Atrule"]],
+        ["atrule", ["Atrule"]],
+        ["declaration", ["Declaration"]],
+    ]),
+
+    matchesSelectorClass(className, node, ancestry) {
+        switch (className.toLowerCase()) {
+            case "rule":
+                return node.type === "Rule" || node.type === "Atrule";
+            case "at-rule":
+            case "atrule":
+                return node.type === "Atrule";
+            case "declaration":
+                return node.type === "Declaration";
+            default:
+                throw new Error(`Unknown class name: ${className}`);
+        }
+    },
+};
 ```
 
-Without this interface method, the CSS plugin would need to request a core change to add its own hardcoded mapping — exactly the coupling this proposal eliminates.
+### 5. Core `esquery.js` Changes
 
-### Core `esquery.js` Changes
-
-The `analyzeParsedSelector()` function (currently at [line 148](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L148)) is updated to accept a `getSelectorClassNodeTypes` parameter, which is passed into the inner `analyzeSelector()` closure:
+In `lib/linter/esquery.js`, `analyzeParsedSelector()` accepts `selectorClassNodeTypes`:
 
 ```diff
 -function analyzeParsedSelector(parsedSelector) {
-+function analyzeParsedSelector(parsedSelector, getSelectorClassNodeTypes) {
-     // ...
++function analyzeParsedSelector(parsedSelector, selectorClassNodeTypes) {
+     let attributeCount = 0;
+     let identifierCount = 0;
+
      function analyzeSelector(selector) {
-         // ...
-         case "class":
--            // TODO: abstract into JSLanguage somehow
--            if (selector.name === "function") {
--                return [
--                    "FunctionDeclaration",
--                    "FunctionExpression",
--                    "ArrowFunctionExpression",
--                ];
--            }
--            return null;
-+            return getSelectorClassNodeTypes(selector.name) ?? null;
+         switch (selector.type) {
+             // ...
+             case "class":
+-                // TODO: abstract into JSLanguage somehow
+-                if (selector.name === "function") {
+-                    return [
+-                        "FunctionDeclaration",
+-                        "FunctionExpression",
+-                        "ArrowFunctionExpression",
+-                    ];
+-                }
+-                return null;
++                return selectorClassNodeTypes?.get(selector.name.toLowerCase()) ?? null;
+         }
      }
- }
 ```
 
-Because `parse()` defaults `getSelectorClassNodeTypes` to a shared no-op function (see "Method-Keyed Selector Cache" below), the method is always callable here — no optional chaining needed. The trailing `?? null` preserves the "any node type could match" fallback for the no-op case (which returns `null`) and for any language method that explicitly returns `null`.
-
-The exported `parse()` function (currently at [line 288](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L288)) is updated to accept an optional `getSelectorClassNodeTypes` parameter and pass it through:
+`parse()` accepts `selectorClassNodeTypes` and keys the cache by the map reference:
 
 ```diff
++const DEFAULT_SELECTOR_CACHE = new Map();
++const selectorCacheByMap = new WeakMap();
++
++function getMapCache(selectorClassNodeTypes) {
++    if (!selectorClassNodeTypes) {
++        return DEFAULT_SELECTOR_CACHE;
++    }
++    let cache = selectorCacheByMap.get(selectorClassNodeTypes);
++    if (!cache) {
++        cache = new Map();
++        selectorCacheByMap.set(selectorClassNodeTypes, cache);
++    }
++    return cache;
++}
+
 -function parse(source) {
 -    if (selectorCache.has(source)) {
 -        return selectorCache.get(source);
-+function parse(source, getSelectorClassNodeTypes = NO_OP_SELECTOR_CLASS) {
-+    const cache = getMethodCache(getSelectorClassNodeTypes);
+-    }
++function parse(source, selectorClassNodeTypes) {
++    const cache = getMapCache(selectorClassNodeTypes);
 +
 +    if (cache.has(source)) {
 +        return cache.get(source);
-     }
++    }
 
      const cleanSource = source.replace(/:exit$/u, "");
      const parsedSelector =
          trySimpleParseSelector(cleanSource) ?? tryParseSelector(cleanSource);
      const { nodeTypes, attributeCount, identifierCount } =
 -        analyzeParsedSelector(parsedSelector);
-+        analyzeParsedSelector(parsedSelector, getSelectorClassNodeTypes);
++        analyzeParsedSelector(parsedSelector, selectorClassNodeTypes);
 
      const result = new ESQueryParsedSelector(
          source,
@@ -181,132 +223,113 @@ The exported `parse()` function (currently at [line 288](https://github.com/esli
  }
 ```
 
-### Method-Keyed Selector Cache
+Keying the cache by the `Map` reference assumes `selectorClassNodeTypes` is immutable after the language is created, the same assumption already made for `visitorKeys`. If a language mutated the map after a selector was cached, the cached analysis would go stale, so languages should treat it as a fixed, read-only property.
 
-Currently, `esquery.js` uses a single global `Map` ([line 114](https://github.com/eslint/eslint/blob/main/lib/linter/esquery.js#L114): `const selectorCache = new Map()`) to cache parsed selectors. Since `getSelectorClassNodeTypes()` can return different results for different languages, the same selector string (e.g., `:function`) may produce different `nodeTypes` arrays depending on which language is active.
+### 6. `SourceCodeTraverser` Changes
 
-The cache is replaced with a `WeakMap` keyed by the language's `getSelectorClassNodeTypes` method reference, so each language gets its own `Map<string, ESQueryParsedSelector>`:
-
-```js
-// Replaces: const selectorCache = new Map();
-const NO_OP_SELECTOR_CLASS = () => null;
-const selectorCacheByMethod = new WeakMap();
-
-function getMethodCache(getSelectorClassNodeTypes) {
-    let cache = selectorCacheByMethod.get(getSelectorClassNodeTypes);
-    if (!cache) {
-        cache = new Map();
-        selectorCacheByMethod.set(getSelectorClassNodeTypes, cache);
-    }
-    return cache;
-}
-```
-
-ESLint languages are exported as singleton object literals (e.g., `lib/languages/js/index.js` exports its language as a `module.exports` object literal), so the method reference is stable for the lifetime of the process. Keying on the method therefore gives each language its own cache bucket without requiring a language identifier on the `Language` interface.
-
-Using `WeakMap` ensures that if a language (and hence its method) is no longer reachable, it can be garbage collected, preventing memory leaks. Languages that do not implement `getSelectorClassNodeTypes` use a shared `NO_OP_SELECTOR_CLASS` function as the default at the `parse()` boundary. All such languages share one cache bucket, which is correct because they all produce the same (null) static-analysis result. This eliminates a separate fallback cache and keeps `getMethodCache` free of special cases.
-
-Note: In practice, ESLint currently only uses one language per file (see [source-code-traverser.js line 269-275](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L269-L275)), but a multi-language lint run will process different files with different languages sequentially, so the method-keyed cache prevents stale optimization data from being reused across languages.
-
-### Source Code Traverser Changes
-
-The [`SourceCodeTraverser`](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js) already stores the language as a private field `#language` (set in the constructor at [line 249](https://github.com/eslint/eslint/blob/main/lib/linter/source-code-traverser.js#L249)). The only changes needed are:
-
-1. Pass the method directly through the `esqueryOptions` object when constructing `ESQueryHelper`, consistent with how `matchesSelectorClass`, `visitorKeys`, and `nodeTypeKey` are already passed individually:
+In `lib/linter/source-code-traverser.js`, pass `selectorClassNodeTypes` through `esqueryOptions`:
 
 ```diff
- // In SourceCodeTraverser.traverseSync() (line 269)
+ // In SourceCodeTraverser.prototype.traverseSync()
  traverseSync(sourceCode, visitor, { steps } = {}) {
      const esquery = new ESQueryHelper(visitor, {
          visitorKeys: sourceCode.visitorKeys ?? this.#language.visitorKeys,
          fallback: vk.getKeys,
          matchClass: this.#language.matchesSelectorClass ?? (() => false),
          nodeTypeKey: this.#language.nodeTypeKey,
-+        getSelectorClassNodeTypes: this.#language.getSelectorClassNodeTypes,
++        selectorClassNodeTypes: this.#language.selectorClassNodeTypes,
      });
 ```
 
-2. In the `ESQueryHelper` constructor, store the method and pass it to `parse()`:
-
 ```diff
- // In ESQueryHelper constructor (line 52)
+ // In the ESQueryHelper constructor
  constructor(visitor, esqueryOptions) {
-+    this.getSelectorClassNodeTypes = esqueryOptions.getSelectorClassNodeTypes;
+     this.visitor = visitor;
+     this.esqueryOptions = esqueryOptions;
++    this.selectorClassNodeTypes = esqueryOptions?.selectorClassNodeTypes;
      // ...
      visitor.forEachName(rawSelector => {
 -        const selector = parse(rawSelector);
-+        const selector = parse(rawSelector, this.getSelectorClassNodeTypes);
++        const selector = parse(rawSelector, this.selectorClassNodeTypes);
          // ... rest unchanged
      });
  }
 ```
 
+## Documentation
+
+This feature requires updating the following:
+
+* The `Language` interface type definitions in [`@eslint/core`](https://github.com/eslint/rewrite/tree/main/packages/core), to add the optional `selectorClassNodeTypes` property.
+* The [Languages](https://eslint.org/docs/latest/extend/languages) documentation, which lists the properties and methods of the `Language` object. `selectorClassNodeTypes` should be documented alongside `matchesSelectorClass()`, noting that the node types it declares must cover every node type `matchesSelectorClass()` can match for the same class.
+
+No blog announcement is needed. This is an additive, opt-in extension point for language plugin authors.
+
 ## Drawbacks
 
-1. **Increased Language interface surface.** Adding a new optional method increases the size of the Language contract. However, it is optional with a safe fallback, so existing language implementations are unaffected.
+- **Desynchronization risk:** If a language plugin updates `matchesSelectorClass()` to match a new AST node type but forgets to update `selectorClassNodeTypes`, the traverser skips dispatching the selector on those nodes, and rules silently fail to execute with no error or warning.
+- **Limited to enumerable types:** Dynamic or pattern-based pseudo-classes like `:statement` or `:expression` cannot be statically narrowed and must return `null` to evaluate against all visited nodes.
 
-2. **Potential for inconsistency.** A language could implement `matchesSelectorClass()` and `getSelectorClassNodeTypes()` inconsistently (e.g., `matchesSelectorClass` handles `:function` but `getSelectorClassNodeTypes` doesn't list the right types). The consequence of such inconsistency is only reduced optimization (more nodes checked than necessary), not incorrect behavior. This is a major design strength: static analysis is advisory only, and runtime matching via `matchesSelectorClass()` remains authoritative. Under this design, plugin authors cannot cause false negatives through an imprecise `getSelectorClassNodeTypes()` implementation. At worst, the traverser checks more nodes than strictly necessary. The only way incorrect behavior could arise is if ESLint core itself misused the static analysis results to skip runtime matching, which this design explicitly avoids.
+## Backwards Compatibility Analysis
 
-3. **Cache complexity.** The cache changes from a simple global `Map` to a `WeakMap` of `Map`s. This is slightly more complex, but the added complexity is minimal and localized to `esquery.js`.
-
-4. **Small scope.** The current optimization affects a relatively small part of the selector pipeline, so the primary benefit of this proposal is architectural consistency and extensibility rather than a large performance gain.
-
-## Backwards Compatibility
-
-This change is **fully backwards compatible**:
-
-1. **`getSelectorClassNodeTypes()` is optional.** If a language does not implement it, the core falls back to `null` (match any type). This is the current behavior for all pseudo-classes except `:function` in JS.
-
-2. **JS behavior is preserved.** The JavaScript language object will implement `getSelectorClassNodeTypes()` with the exact same mapping currently hardcoded in `esquery.js`. End users will see no behavioral difference.
-
-3. **`parse()` API is backwards compatible.** The `getSelectorClassNodeTypes` parameter is optional and defaults to a shared no-op function. Calling `parse(source)` without it continues to work; class selectors receive `null` node types, identical to the pre-change behavior for all non-`:function` selectors.
-
-4. **No breaking changes for language plugins.** Existing language plugins (CSS, Markdown, JSON, HTML, YAML) do not need to implement this method. They will simply not benefit from the optimization until they choose to.
-
-5. **Type definitions.** The method is added as an optional property (`getSelectorClassNodeTypes?`) in `@eslint/core`'s `Language` interface, so existing TypeScript users are unaffected.
+1. **`selectorClassNodeTypes` is optional.** If omitted, static analysis returns `null` for class selectors, meaning candidate nodes are not narrowed during parsing and all nodes are evaluated during traversal. This matches the current behavior for all non-`:function` pseudo-classes.
+2. **JavaScript behavior is unchanged.** The JS language object declares the same three function node types currently in `esquery.js`.
+3. **`parse(source)` without options.** Calling `parse` without a second argument falls back to `DEFAULT_SELECTOR_CACHE` and returns `null` for all class selectors. This is a change from today, where `parse(":function")` returns the three JS function node types from the hardcoded branch. It is internal-only: the traverser always passes the active language's `selectorClassNodeTypes`, so the JS language still resolves `:function` to those node types in practice.
+4. **Existing plugins.** Language plugins without this property continue to function without modification.
+5. **Unknown class names still throw.** Passing a class the language doesn't define, like `:foo`, throws `Error: Unknown class name` from `matchesSelectorClass()`, exactly as it does today. Static analysis only narrows which nodes a selector is dispatched on; it never changes whether a selector matches.
 
 ## Alternatives
 
-### 1. Move Logic Without a Language Interface Method
+### 1. Method: `getSelectorClassNodeTypes(className)`
 
-Move the hardcoded logic into a helper function that checks the language identity (e.g., `if (language === jsLanguage)`) rather than adding a generic interface method. This removes the hardcoding from `esquery.js` but doesn't provide a generic solution for other languages and still couples the core to the JS language.
+The initial draft proposed a method on `Language`. A plain `Map` property was chosen instead based on maintainer feedback: mapping pseudo-class names to static node type arrays is fixed data rather than dynamic behavior, so a property map is simpler and avoids introducing an unnecessary method to the interface.
 
-### 2. Use `matchesSelectorClass()` for Static Analysis
+### 2. Check JS Language Identity in Core Helpers
 
-Instead of adding a new method, try to infer possible types by calling `matchesSelectorClass()` against a set of known node types. This is impractical because:
-- ESLint core has no canonical registry of all node types for arbitrary languages, so exhaustive inference would require language-specific enumeration anyway.
-- It would require instantiating dummy nodes for every possible type.
-- It conflates runtime matching with static analysis.
+Move the `:function` logic to a helper in core that checks whether the active language is the JS language. This would remove the inline `case "class"` branch from `esquery.js` but keeps the core coupled to JS and does not provide an extension point for language plugins.
 
-### 3. Extend `matchesSelectorClass()` to Return Type Information
+### 3. Infer Node Types via `matchesSelectorClass()` Probing
 
-Instead of a separate method, modify `matchesSelectorClass()` to optionally return type information. This was rejected because it changes the semantics of an existing method and makes the return type complex (boolean vs. type array).
-
+Call `matchesSelectorClass()` against mock nodes at parse time to infer types. This is not feasible because ESLint core does not maintain a comprehensive registry of all AST node types for arbitrary languages, and creating dummy nodes for every type would be slow and fragile.
 
 ## Open Questions
 
-1. **Method naming.** The proposed name `getSelectorClassNodeTypes` was chosen for conciseness and alignment with ESLint core conventions. It is directly tied to selector classes, avoids the unnecessary "possible" qualifier (static analysis inherently implies possibility, not certainty), and keeps the return semantics clear from the documented contract. The team may prefer a different name.
+Should a class selector that isn't declared in `selectorClassNodeTypes` match all nodes, or should it be pruned from traversal entirely?
 
-2. **Should language authors be encouraged to implement this for all their pseudo-classes?** For pseudo-classes defined by structural or naming conventions (like `:statement` matching `*Statement`), returning `null` is appropriate since the matching set is open-ended. Should the documentation explicitly guide authors on when to return `null` vs. an explicit list?
+Today the two code paths disagree, and this RFC preserves that behavior:
 
-3. **Cache eviction strategy.** The `WeakMap` approach means caches are evicted when a language's `getSelectorClassNodeTypes` method becomes unreachable. In practice, language objects (and their methods) are long-lived (often singletons). Languages without the method share a single cache bucket keyed on the module-level `NO_OP_SELECTOR_CLASS`. Should we consider adding a size limit to per-method caches, or is unbounded growth acceptable given the finite number of selectors in a typical lint run?
+- Static analysis returns `null` for an undeclared class, which places the selector in the any-type list so it is evaluated on every node during traversal.
+- At runtime, `matchesSelectorClass()` decides the actual match. For a truly unknown class (one the language doesn't define), it throws `Error: Unknown class name` as it does today.
+
+So an undeclared-but-known class like `:statement` safely falls back to evaluating on all nodes, while an unknown class like `:foo` still throws. Whether "match all nodes" is the right default for undeclared classes, or whether they should instead be pruned, is the main question I'd like reviewers to weigh in on.
 
 ## Help Needed
 
-I am willing to submit a pull request with the reference implementation for this RFC once it is accepted. The change should be performance-neutral outside selector parsing and traversal narrowing.
+I'm able to implement this myself and will open the reference implementation in `eslint/eslint` once the RFC is accepted.
+
+Measuring the traversal impact will need a dedicated benchmark built around a `:function`-based rule. Recommended rules like `no-shadow-restricted-names` already register `:function`, so the general `npm run test:performance` suite exercises this path in aggregate but can't isolate its cost; a focused benchmark is needed for a clean signal.
 
 ## Frequently Asked Questions
 
-**Q: Why not wait until there's a concrete non-JS language that needs this?**
+**Why use a `Map` instead of a plain object (`Record<string, Array<string>>`)?**
 
-A: While the immediate benefit is architectural, making this change now is low-risk (fully backwards compatible, optional method) and avoids accumulating more JS-specific debt in the core. It also sends a clear signal to language plugin authors that the optimization path exists.
+A plain object risks inherited-key collisions: a lookup for a class name like `constructor` or `toString` returns an `Object.prototype` member unless you use a null-prototype object or `hasOwn` checks. A `Map` avoids that. It also gives explicit `.get()` / `.has()` semantics and works as a stable object reference for keying the `WeakMap` selector cache. (`visitorKeys` stays a plain object because its keys are fixed AST node type names, which don't have this problem.)
 
-**Q: Does this change affect how `matchesSelectorClass()` works?**
+**Why does JavaScript only declare `:function` and omit `:statement` or `:expression`?**
 
-A: No. `matchesSelectorClass()` continues to handle runtime matching exactly as before. `getSelectorClassNodeTypes()` is a separate, complementary method used only during selector parsing for static analysis.
+Statements and expressions each cover dozens of ESTree node types, and dialects like JSX or TypeScript add more. Hardcoding those lists in core would be brittle across AST versions. Leaving them out lets static analysis fall back to `null` (evaluate on all nodes) while `matchesSelectorClass()` matches them at runtime via suffix checks like `*Statement` and `*Declaration`.
+
+**What happens if a plugin's `selectorClassNodeTypes` omits a node type that `matchesSelectorClass()` matches?**
+
+The traverser skips dispatching the selector on those node types, which silently drops matches. The rule of thumb is to declare a class in `selectorClassNodeTypes` only when its node types are fixed and exhaustive; when they aren't, omit the entry and fall back to `null`.
+
+**How does this interact with custom parsers (like `@typescript-eslint/parser`) using the JavaScript language?**
+
+`:function` narrows to the standard ESTree function types. For parser-specific node types like `TSDeclareFunction`, rules can target them with a direct node selector, or the parser can ship its own `Language` plugin with its own `selectorClassNodeTypes` if it wants custom pseudo-class semantics.
 
 ## Related Discussions
 
-- [Discussion #20856](https://github.com/eslint/eslint/discussions/20856) — Original discussion: "Should we move JS-specific ESQuery analysis logic into the Language interface?"
-- [RFC #99](https://github.com/eslint/rfcs/pull/99) — ESLint Language Plugins (introduced the Language interface)
-- [esquery External class resolve PR](https://github.com/estools/esquery/pull/140) — The mechanism that enabled `matchesSelectorClass()`
+- [Discussion #20856: Should we move JS-specific ESQuery analysis logic into the Language interface?](https://github.com/eslint/eslint/discussions/20856)
+- [RFC #99: ESLint Language Plugins](https://github.com/eslint/rfcs/pull/99)
+- [RFC PR #148: Pull Request for this RFC](https://github.com/eslint/rfcs/pull/148)
+- [esquery PR #140: External class resolution mechanism](https://github.com/estools/esquery/pull/140)


### PR DESCRIPTION
## Summary

Add an optional getPossibleTypesForSelectorClass(className) method to the Language interface that allows languages to declare which AST node types could match a given pseudo-class selector (e.g., :function). This removes hardcoded JavaScript-specific logic from the core selector analysis in lib/linter/esquery.js and enables any language plugin to provide the same optimization.

## Related Issues

- [Discussion #20856](https://github.com/eslint/eslint/discussions/20856) — Original discussion: "Should we move JS-specific ESQuery analysis logic into the Language interface?"
- [RFC #99](https://github.com/eslint/rfcs/pull/99) — ESLint Language Plugins (introduced the Language interface)
- [esquery External class resolve PR](https://github.com/estools/esquery/pull/140) — The mechanism that enabled `matchesSelectorClass()`

